### PR TITLE
Add doc home page for Splinter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Splinter Documentation
 
-[Splinter](https://github.com/Cargill/splinter) is a privacy-focused platform
-for distributed applications that provides a blockchain-inspired networking
-environment for private communication and transactions between organizations.
-The open-source Splinter software is hosted at
-[github.com/Cargill/splinter](https://github.com/Cargill/splinter).
+Splinter is a privacy-focused platform for distributed applications that
+provides a blockchain-inspired networking environment for private communication
+and transactions between organizations. The open-source Splinter software is
+hosted at [github.com/Cargill/splinter](https://github.com/Cargill/splinter).
 
-This repository contains the source files for the Splinter documentation,
+This repository contains the source files for the [Splinter
+documentation](docs/index.md), which is
 in [GitHub Flavored Markdown](https://github.github.com/gfm/) (GFM) format.
+For more information, see [docs/README.md](docs/README.md).
 
 ## License
 
@@ -21,6 +22,6 @@ licensed under the [Apache License Version 2.0](LICENSE) software license.
 
 ## Code of Conduct
 
-The Splinter documentation, like the [Splinter source
-code](https://github.com/Cargill/splinter), operates under the [Cargill Code of
+The Splinter documentation, like the Splinter source code, operates under the
+[Cargill Code of
 Conduct](https://github.com/Cargill/code-of-conduct/blob/master/code-of-conduct.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # About the splinter/docs directory
 
-This directory contains the source files for the Splinter documentation.
+This directory contains the source files for the [Splinter
+documentation](index.md).
 
 Splinter documentation is written in
 [GitHub Flavored Markdown](https://github.github.com/gfm/) (GFM).
@@ -8,31 +9,34 @@ For a quick reference, see this
 [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
 from [adam-p/markdown-here](https://github.com/adam-p/markdown-here).
 
-The documentation files are stored in the following subdirectories:
+The documentation is organized as follows:
 
-* ``community``: Topics that describe how to participate in the Splinter
+* ``index.md``: [Documentation home](index.md) (landing page with links
+  to documentation contents).
+
+* ``community/``: Topics that describe how to participate in the Splinter
   community and contribute to the Splinter repositories.
 
-* ``concepts``: Topics that explain Splinter concepts, architecture, features,
+* ``concepts/``: Topics that explain Splinter concepts, architecture, features,
   and other non-procedure information. File names should reflect the topic
   title, using all lowercase and optional underscores between words; for
   example, ``circuits.md`` or ``state_delta_export.md``.
 
-* ``faq``: Splinter FAQ in one or more files. The main page, ``faq.md``,
+* ``faq/``: Splinter FAQ in one or more files. The main page, ``faq.md``,
   introduces the FAQ and contains the first few questions. Other files can be
   added as necessary to divide the FAQ into sections.
 
-* ``glossary``: Definitions of Splinter terms in the file ``glossary.md``.
+* ``glossary/``: Definitions of Splinter terms in the file ``glossary.md``.
 
-* ``howto``: Procedures for specific tasks (such as configuring Splinter,
+* ``howto/``: Procedures for specific tasks (such as configuring Splinter,
   setting permissions, using a feature, or running example demos). File names
   should be verb phrases that reflect the topic title, using all lowercase and
   optional underscores between words; for example, ``upgrading_splinter.md``
   or ``creating_the_node_registry.md``.
 
-* ``images``: Graphics, pictures, diagrams, icons and other images in the
+* ``images/``: Graphics, pictures, diagrams, icons and other images in the
   Splinter documentation. PNG format is preferred; GIF or JPG is allowed.
   (SVG files are not supported.)
 
-* ``tutorials``: In-depth, multi-section procedures for complex tasks, such as
+* ``tutorials/``: In-depth, multi-section procedures for complex tasks, such as
   creating an application.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ and transactions between organizations.
   * [Splinter glossary](glossary/glossary.md): Definitions for _circuit_, _scabbard_,
     _state delta export_, and more
 
+  * [About Canopy](concepts/about_canopy.md): Splinter's distributed-application
+    UI framework that dynamically loads saplings (application UI components)
+
 ## Example Applications
 
   * [Gameroom](https://github.com/Cargill/splinter/blob/master/examples/gameroom/README.md):

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+# Splinter Documentation
+
+Splinter is a privacy-focused platform for distributed applications that
+provides a blockchain-inspired networking environment for private communication
+and transactions between organizations.
+
+## Getting Started
+
+  * [About Splinter](https://github.com/Cargill/splinter/blob/master/README.md)
+
+  * [Splinter FAQ](faq/faq.md)
+
+## Concepts
+
+  * [Splinter glossary](glossary/glossary.md): Definitions for _circuit_, _scabbard_,
+    _state delta export_, and more
+
+## Example Applications
+
+  * [Gameroom](https://github.com/Cargill/splinter/blob/master/examples/gameroom/README.md):
+    Complete application that uses the scabbard service
+
+  * [Private XO](https://github.com/Cargill/splinter/blob/master/examples/private_xo/README.md)
+    and
+    [Private Counter](https://github.com/Cargill/splinter/blob/master/examples/private_counter/README.md):
+    Low-level examples of how to write a service
+
+## For Developers
+
+Splinter is an open-source project hosted at
+[github.com/Cargill/splinter](https://github.com/Cargill/splinter).
+This project operates under the [Cargill Code of
+Conduct](https://github.com/Cargill/code-of-conduct/blob/master/code-of-conduct.md).
+
+  * [Splinter release
+    notes](https://github.com/Cargill/splinter/blob/master/RELEASE_NOTES.md)
+
+  * [Stable feature checklist](community/stable_feature_checklist.md)
+
+## License
+
+Splinter software is licensed under the [Apache License Version
+2.0](https://github.com/Cargill/splinter/blob/master/LICENSE) software license.
+
+The Splinter documentation in the
+[splinter-docs repository](https://github.com/Cargill/splinter-docs)
+is licensed under a Creative Commons Attribution 4.0 International License
+(CC BY 4.0). You can obtain a copy of the license at
+<http://creativecommons.org/licenses/by/4.0/>.
+
+The Splinter documentation tools and associated content in this repository are
+licensed under the [Apache License Version
+2.0](https://github.com/Cargill/splinter/blob/master/LICENSE) software license.


### PR DESCRIPTION
The docs/index.md file is a "landing page" for the Splinter documentation
It contains links to the available Markdown-format documentation in the
splinter-docs repo. (This approach is temporary until the publishing tools and
a doc hosting site are available.)

This PR also adds links to this file from the main and docs READMEs
and updates the repo organization info in docs/README.

Signed-off-by: Anne Chenette <chenette@bitwise.io>