### PR TITLE
Add link to Rust doc for crate splinter 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,11 @@ Conduct](https://github.com/Cargill/code-of-conduct/blob/master/code-of-conduct.
 
   * [Stable feature checklist](community/stable_feature_checklist.md)
 
+## Reference Guides
+
+  * [Splinter API Reference](https://docs.rs/splinter):
+    Documentation for the Rust `splinter` crate
+
 ## License
 
 Splinter software is licensed under the [Apache License Version


### PR DESCRIPTION
Add a new "Reference Guides" section to the main Splinter doc page
with a link to the Splinter API Reference at https://docs.rs/splinter

Signed-off-by: Anne Chenette <chenette@bitwise.io>