### PR TITLE
Add CLI Command Reference section and add splinter cert generate file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ The documentation is organized as follows:
 * ``community/``: Topics that describe how to participate in the Splinter
   community and contribute to the Splinter repositories.
 
+* ``references/``: Reference guides for Splinter.
+
 * ``concepts/``: Topics that explain Splinter concepts, architecture, features,
   and other non-procedure information. File names should reflect the topic
   title, using all lowercase and optional underscores between words; for

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,9 @@ Conduct](https://github.com/Cargill/code-of-conduct/blob/master/code-of-conduct.
   * [Splinter API Reference](https://docs.rs/splinter):
     Documentation for the Rust `splinter` crate
 
+  * [Splinter CLI Command Reference](references/cli/cli_command_reference.md):
+    Documentation for the Splinter CLIs
+
 ## License
 
 Splinter software is licensed under the [Apache License Version

--- a/docs/references/cli/cli_command_reference.md
+++ b/docs/references/cli/cli_command_reference.md
@@ -1,0 +1,6 @@
+# CLI Command Reference
+
+The `splinter` command-line interface (CLI) provides a set of commands to interact
+with Splinter components:
+
+  * [splinter cert generate](splinter-cert-generate.1.md)

--- a/docs/references/cli/splinter-cert-generate.1.md
+++ b/docs/references/cli/splinter-cert-generate.1.md
@@ -1,0 +1,95 @@
+% SPLINTER-CERT-GENERATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-cert-generate** — Generates test certificates and keys for running
+  splinterd with TLS (in insecure mode)
+
+SYNOPSIS
+========
+| **splinter cert generate** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Running Splinter in TLS mode requires valid X.509 certificates from a
+certificate authority. When developing against Splinter, you can use this
+command to generate development certificates and the associated keys for your
+development environment.
+
+The files are generated in the location specified by `--cert-dir`, the
+SPLINTER_CERT_DIR environment variable, or in the default location
+/etc/splinter/certs/.
+
+The following files are created:
+
+  client.crt, client.key, server.crt, server.key, generated_ca.pem,
+  generated_ca.key
+
+FLAGS
+=====
+`--force`
+: Overwrites files if they exist. If this flag is not provided and the file
+  exists, an error is returned.
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`--skip`
+: Checks if the files exists and generates the files that are missing. If this
+flag is not provided and the file exists, an error is returned.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-d`, `--cert-dir <cert_dir>`
+: Path to the directory certificates are created in. Defaults to
+  /etc/splinter/certs/. This location can also be changed with the
+  SPLINTER_CERT_DIR environment variable. This directory must exist.
+
+`--common-name <common_name>`
+: String that specifies a common name for the generated certificate (defaults to
+  localhost). Use this option if the splinterd URL uses a DNS address instead
+  of a numerical IP address.
+
+EXAMPLES
+========
+Generates test certificates and keys:
+
+  `$ splinter cert generate`
+
+To create missing certificates and keys when some files already exist, add the
+`--skip` flag. The command will ignore the existing files and create any files
+that are missing.
+
+  `$ splinter cert generate --skip`
+
+To recreate the certificates and keys from scratch, use the  `--force` flag to
+overwrite all existing files.
+
+  `$ splinter cert generate --force`
+
+ENVIRONMENT
+===========
+The following environment variables affect the execution of splinter cert
+generate:
+
+**SPLINTER_CERT_DIR**
+
+: The certificates and keys will be generated at the location specified by the
+  environment variable.  (See `--cert-dir`)
+
+SEE ALSO
+========
+For more information, see the Splinter documentation at
+https://github.com/Cargill/splinter-docs/blob/master/docs/index.md


### PR DESCRIPTION
This PR adds a location for the markdown man pages that are included in the splinter cli and copies over the file for `splinter cert generate`