### PR TITLE
Update `circuit create` to `circuit propose`

### DIFF
--- a/docs/howto/uploading_smart_contract.md
+++ b/docs/howto/uploading_smart_contract.md
@@ -18,7 +18,7 @@ two nodes and upload a smart contract via the circuit.
     a. Propose the circuit on alpha node.
 
     ```
-    $ splinter circuit create \
+    $ splinter circuit propose \
         --url http://splinterd-alpha:8085 \
         --key <path_to_alpha_private_key> \
         --node alpha-node-000::tls://splinterd-alpha:8044 \


### PR DESCRIPTION
Updates the circuit create command to circuit propose in the "Uploading
a Smart Contract" document, since this has been changed in the Splinter
CLI.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

This PR should not be merged until the corresponding change in splinter has been merged: Cargill/splinter#609