### PR TITLE
Update generating cert doc for new tls options

### DIFF
--- a/docs/howto/generating_insecure_certificates_for_development.md
+++ b/docs/howto/generating_insecure_certificates_for_development.md
@@ -3,11 +3,11 @@
 This document describes how to use the `splinter` CLI to generate certificates
 for running the Splinter daemon in a development environment.
 
-The Splinter daemon can be run with raw TCP connections or with TLS connections.
-When developing against Splinter, you might want to run in TLS mode without the
-effort of getting valid X.509 certificates from a certificate authority. If so,
-you can use the `splinter` CLI to generate insecure certificates and the
-associated keys.
+The Splinter daemon can be run with raw TCP connections and with TLS
+connections. When developing against Splinter, you might want to run in TLS mode
+without the effort of getting valid X.509 certificates from a certificate
+authority. If so, you can use the `splinter` CLI to generate insecure
+certificates and the associated keys.
 
 The `splinter cert generate` command creates the following certificates and
 keys:

--- a/docs/howto/generating_insecure_certificates_for_development.md
+++ b/docs/howto/generating_insecure_certificates_for_development.md
@@ -26,7 +26,7 @@ This command writes the files to the default Splinter certificate directory,
 `/etc/splinter/certs/`. To use a different directory (for example, if you
 already have valid certificate files in this directory), you can change the
 location by setting the `SPLINTER_CERT_DIR` environment variable or using the
-`--cert_dir` option on the command line.
+`--tls-cert_dir` option on the command line.
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ This procedure requires a local development environment that includes the
 
 1. If you want to change the default certificate directory, set the
    `SPLINTER_CERT_DIR` environment variable. (Otherwise, you could
-   use the `--cert_dir` option with the `splinter` and `splinterd`
+   use the `--tls-cert_dir` option with the `splinter` and `splinterd`
    commands in this procedure.)
 
 1. Run the following command to generate certificates and keys.
@@ -65,19 +65,19 @@ This procedure requires a local development environment that includes the
 
 1. Start the Splinter daemon in TLS mode with the following `splinterd` command.
 
-   The `--insecure` flag turns off certificate authority validation (because the
-   generated certificates are not signed by a common certificate authority).
+   The `--tls-insecure` flag turns off certificate authority validation (because
+   the generated certificates are not signed by a common certificate authority).
    Without this flag, the Splinter daemon will get a TLS error when it tries to
    connect to another Splinter node.
 
    ```
-   $ splinterd --node-id node-000 --insecure --network-endpoint tcps://127.0.0.1:8044
+   $ splinterd --node-id node-000 --tls-insecure --network-endpoint tcps://127.0.0.1:8044
    [2020-02-04 15:40:29.763] T["main"] WARN [splinterd] Starting TlsTransport in insecure mode
    ```
 
    * You can specify the generated certificate directory by using the
-    `--cert-dir` option, setting `SPLINTER_CERT_DIR` environment variable, or
-    setting the location in the splinterd config, `splinterd.toml`. If
+    `--tls-cert-dir` option, setting `SPLINTER_CERT_DIR` environment variable,
+    or setting the location in the splinterd config, `splinterd.toml`. If
     necessary, you can specify each file separately with the command-line option
     or in the config file.
 
@@ -86,7 +86,7 @@ This procedure requires a local development environment that includes the
      keys were used, add `-vv` to increase the logging level.
 
    ```
-   $ splinterd --node-id node-000 --insecure -vv --network-endpoint tcps://127.0.0.1:8044
+   $ splinterd --node-id node-000 --tls-insecure -vv --network-endpoint tcps://127.0.0.1:8044
 
    .
    .
@@ -94,11 +94,11 @@ This procedure requires a local development environment that includes the
    [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: storage: yaml (source: Default)
    [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: transport: tls (source: CommandLine)
    [2020-02-13 08:50:30.592] T["main"] WARN [splinterd::config] Starting TlsTransport in insecure mode
-   [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: cert_dir: /etc/splinter/certs/ (source: Default)
-   [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: client_cert: /etc/splinter/certs/client.crt (source: Default)
-   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: client_key: /etc/splinter/certs/private/client.key (source: Default)
-   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: server_cert: /etc/splinter/certs/server.crt (source: Default)
-   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: server_key: /etc/splinter/certs/private/server.key (source: Default)
+   [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: tls_cert_dir: /etc/splinter/certs/ (source: Default)
+   [2020-02-13 08:50:30.592] T["main"] DEBUG [splinterd::config] Config: tls_client_cert: /etc/splinter/certs/client.crt (source: Default)
+   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: tls_client_key: /etc/splinter/certs/private/client.key (source: Default)
+   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: tls_server_cert: /etc/splinter/certs/server.crt (source: Default)
+   [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: tls_server_key: /etc/splinter/certs/private/server.key (source: Default)
    [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: service_endpoint: tcp://127.0.0.1:8043 (source: Default)
    [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: network_endpoint: tcps://127.0.0.1:8044 (source: Default)
    [2020-02-13 08:50:30.593] T["main"] DEBUG [splinterd::config] Config: peers: [] (source: Default)


### PR DESCRIPTION
Update docs for the changes in Cargill/splinter#727

This should be merged after Cargill/splinter#727