### PR TITLE
Remove Private Counter + XO demos from docs

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -21,10 +21,11 @@ For more information, see the
 
 ## Does Splinter have any example applications?
 
-The [cargill/splinter repository](https://github.com/Cargill/splinter/tree/master/examples)
-includes several example applications that you can run as demos. For more
-information, see the [Splinter README:
-Demos](https://github.com/Cargill/splinter/blob/master/README.md#demos).
+Yes. [Gameroom](https://github.com/Cargill/splinter/tree/master/examples/gameroom)
+is a complete web application that allows you to set up private, multi-party
+circuits (called "gamerooms") and play tic tac toe with securely shared state.
+For more information, see the
+[Gameroom README](https://github.com/Cargill/splinter/blob/master/examples/gameroom/README.md).
 
 ## How can I learn more about Splinter?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,12 +28,8 @@ and transactions between organizations.
 ## Example Applications
 
   * [Gameroom](https://github.com/Cargill/splinter/blob/master/examples/gameroom/README.md):
-    Complete application that uses the scabbard service
-
-  * [Private XO](https://github.com/Cargill/splinter/blob/master/examples/private_xo/README.md)
-    and
-    [Private Counter](https://github.com/Cargill/splinter/blob/master/examples/private_counter/README.md):
-    Low-level examples of how to write a service
+    Web application that allows you to set up private multi-party circuits and
+    play tic tac toe with securely shared state
 
 ## For Developers
 


### PR DESCRIPTION
Reword demo-related content in doc index and FAQ now that the Private Counter
and Private XO examples are gone (deleted from the splinter repo a while back).

Signed-off-by: Anne Chenette <chenette@bitwise.io>