### PR TITLE
Set layouts via _config.yml file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,20 @@ exclude:
   - docker*
   - LICENSE
   - MAINTAINERS.md
+
+defaults:
+    - scope:
+        path: "docs/0.4"
+        type: "pages"
+      values:
+        layout: "0.4"
+    - scope:
+        path: "community"
+        type: "pages"
+      values:
+        layout: "community"
+    - scope:
+        path: ""
+        type: "pages"
+      values:
+        layout: "default"

--- a/_layouts/0.4.html
+++ b/_layouts/0.4.html
@@ -21,17 +21,21 @@
     </head>
     <body>
 {% include header.html %}
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-3 col-xl-2"></div>
-        <main class="col-md-9 col-xl-8 main" role="main">
-            <div class="content">
-                {{ content }}
+        <div class="container-fluid">
+            <div class="row">
+                <div id="left-sidebar-col" class="d-none d-md-block col-md-3 col-xl-2 position-fixed sidebar-col">
+{% include left_sidebar.html %}
+                </div>
+                <main id="main" class="col-md-9 col-xl-8 offset-md-3 offset-xl-2" role="main">
+                    <div class="content" id="main-content">
+                        {{ content }}
+                    </div>
+                </main>
+                <div id="right-sidebar-col" class="d-none d-xl-block col-xl-2 offset-xl-10 position-fixed sidebar-col">
+                    <div id="right-sidebar" class="sidebar"></div">
+                </div>
             </div>
-        </main>
-        <div class="col-xl-2"></div>
-    </div>
-</div>
+        </div>
 {% include footer.html %}
     </body>
 {% include scripts.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,21 +21,17 @@
     </head>
     <body>
 {% include header.html %}
-        <div class="container-fluid">
-            <div class="row">
-                <div id="left-sidebar-col" class="d-none d-md-block col-md-3 col-xl-2 position-fixed sidebar-col">
-{% include left_sidebar.html %}
-                </div>
-                <main id="main" class="col-md-9 col-xl-8 offset-md-3 offset-xl-2" role="main">
-                    <div class="content" id="main-content">
-                        {{ content }}
-                    </div>
-                </main>
-                <div id="right-sidebar-col" class="d-none d-xl-block col-xl-2 offset-xl-10 position-fixed sidebar-col">
-                    <div id="right-sidebar" class="sidebar"></div">
-                </div>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-3 col-xl-2"></div>
+        <main class="col-md-9 col-xl-8 main" role="main">
+            <div class="content">
+                {{ content }}
             </div>
-        </div>
+        </main>
+        <div class="col-xl-2"></div>
+    </div>
+</div>
 {% include footer.html %}
     </body>
 {% include scripts.html %}

--- a/community/index.md
+++ b/community/index.md
@@ -1,6 +1,2 @@
----
-layout: community
----
-
 # Splinter Community
 

--- a/community/licensing.md
+++ b/community/licensing.md
@@ -1,7 +1,3 @@
----
-layout: community
----
-
 # Licensing
 
 ## Software

--- a/community/stable_feature_checklist.md
+++ b/community/stable_feature_checklist.md
@@ -1,7 +1,3 @@
----
-layout: community
----
-
 # Stable Feature Checklist
 
 New Splinter features are usually added to the code as experimental.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
----
-layout: landing_page
----
-
 # Splinter Documentation
 
 Splinter is a privacy-focused platform for distributed applications that


### PR DESCRIPTION
This sets the layouts using _config.yml instead of front matter in the
md files. This is nice, in part, because it can be set on a directory
basis.

This also changes default to what was 'landing page' previously and
renames the previously 'default' layout to '0.4'.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>