### PR TITLE
 Add justfile for copying man pages from the splinter repo

### DIFF
--- a/docs/0.4/references/cli/cli_command_reference.md
+++ b/docs/0.4/references/cli/cli_command_reference.md
@@ -1,6 +1,29 @@
 # CLI Command Reference
 
-The `splinter` command-line interface (CLI) provides a set of commands to interact
-with Splinter components:
+The `splinter` command-line interface (CLI) provides a set of commands to
+interact with Splinter components:
 
+  * [splinter](splinter.1.md)
+  * [splinter cert](splinter-cert.1.md)
   * [splinter cert generate](splinter-cert-generate.1.md)
+  * [splinter circuit](splinter-circuit.1.md)
+  * [splinter circuit list](splinter-circuit-list.1.md)
+  * [splinter circuit proposals](splinter-circuit-proposals.1.md)
+  * [splinter circuit propose](splinter-circuit-propose.1.md)
+  * [splinter circuit show](splinter-circuit-show.1.md)
+  * [splinter circuit template](splinter-circuit-template.1.md)
+  * [splinter circuit template
+    arguments](splinter-circuit-template-arguments.1.md)
+  * [splinter circuit template show](splinter-circuit-template-show.1.md)
+  * [splinter circuit template list](splinter-circuit-template-list.1.md)
+  * [splinter circuit vote](splinter-circuit-vote.1.md)
+  * [splinter database](splinter-database.1.md)
+  * [splinter database migrate](splinter-database-migrate.1.md)
+  * [splinter health](splinter-health.1.md)
+  * [splinter health status](splinter-health-status.1.md)
+  * [splinter keygen](splinter-keygen.1.md)
+
+  The `splinterd` command-line interface (CLI) provides the command for running
+  the Splinter daemon.
+
+  * [splinterd](splinterd.1.md)

--- a/docs/0.4/references/cli/splinter-cert-generate.1.md
+++ b/docs/0.4/references/cli/splinter-cert-generate.1.md
@@ -18,13 +18,13 @@ command to generate development certificates and the associated keys for your
 development environment.
 
 The files are generated in the location specified by `--cert-dir`, the
-SPLINTER_CERT_DIR environment variable, or in the default location
-/etc/splinter/certs/.
+`SPLINTER_CERT_DIR` environment variable, or in the default location
+`/etc/splinter/certs/`. Note: The default location could be different if the
+`SPLINTER_HOME` environment variable is set; see the `splinterd(1)` man page
+for more information.
 
-The following files are created:
-
-  client.crt, client.key, server.crt, server.key, generated_ca.pem,
-  generated_ca.key
+The following files are created: `client.crt`, `client.key`, `server.crt`,
+`server.key`, `generated_ca.pem`, and `generated_ca.key`.
 
 FLAGS
 =====
@@ -36,7 +36,7 @@ FLAGS
 : Prints help information
 
 `-q`, `--quiet`
-: Decrease verbosity (the opposite of -v). When specified, only errors or
+: Decreases verbosity (the opposite of -v). When specified, only errors or
   warnings will be output.
 
 `--skip`
@@ -52,19 +52,19 @@ flag is not provided and the file exists, an error is returned.
 
 OPTIONS
 =======
-`-d`, `--cert-dir <cert_dir>`
-: Path to the directory certificates are created in. Defaults to
-  /etc/splinter/certs/. This location can also be changed with the
-  SPLINTER_CERT_DIR environment variable. This directory must exist.
+`-d`, `--cert-dir CERT-DIR`
+: Specifies the path to the directory to contain the certificates and associated
+  key files. (Default: `/etc/splinter/certs/`, unless `SPLINTER_CERT_DIR` or
+  `SPLINTER_HOME` is set). This directory must exist.
 
-`--common-name <common_name>`
-: String that specifies a common name for the generated certificate (defaults to
-  localhost). Use this option if the splinterd URL uses a DNS address instead
-  of a numerical IP address.
+`--common-name COMMON-NAME`
+: Specifies a common name for the generated certificate. (Default: `localhost`.)
+  Use this option if the `splinterd` URL uses a DNS address instead of a
+  numerical IP address.
 
 EXAMPLES
 ========
-Generates test certificates and keys:
+To generate test certificates and keys:
 
   `$ splinter cert generate`
 
@@ -74,22 +74,27 @@ that are missing.
 
   `$ splinter cert generate --skip`
 
-To recreate the certificates and keys from scratch, use the  `--force` flag to
+To recreate the certificates and keys from scratch, use the `--force` flag to
 overwrite all existing files.
 
   `$ splinter cert generate --force`
 
-ENVIRONMENT
-===========
-The following environment variables affect the execution of splinter cert
-generate:
+ENVIRONMENT VARIABLES
+=====================
 
 **SPLINTER_CERT_DIR**
 
-: The certificates and keys will be generated at the location specified by the
-  environment variable.  (See `--cert-dir`)
+: Specifies the directory containing certificates and associated key files
+  (see `--cert-dir`).
+
+**SPLINTER_HOME**
+
+: Changes the base directory path for the Splinter directories, including the
+  certificate directory. (See the `splinterd(1)` man page for more information.)
+  This value is not used if `SPLINTER_CERT_DIR` is set.
 
 SEE ALSO
 ========
-For more information, see the Splinter documentation at
-https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+| `splinterd(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-cert.1.md
+++ b/docs/0.4/references/cli/splinter-cert.1.md
@@ -1,0 +1,54 @@
+% SPLINTER-CERT(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-cert** — Provides certificate management subcommands
+
+SYNOPSIS
+========
+
+**splinter** **cert** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+This command provides subcommands for working with self-signed (insecure)
+certificates in a development environment. For example, the `splinter cert
+generate` subcommand creates these certificates and the associated keys.
+
+Running Splinter in TLS mode usually requires valid X.509 certificates from a
+certificate authority. When developing against Splinter, you can use self-signed
+development certificates in place of the X.509 certificates. These self-signed
+certificates are insecure, so they should only be used in a development
+environment (not in a POC or production environment).
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+
+`generate`
+: Generates insecure certificates for development
+
+SEE ALSO
+========
+| `splinter-cert-generate(1)`
+| 
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+

--- a/docs/0.4/references/cli/splinter-circuit-list.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-list.1.md
@@ -1,0 +1,114 @@
+% SPLINTER-CIRCUIT-LIST(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-list** — Displays the existing circuits for this Splinter node
+
+SYNOPSIS
+========
+**splinter circuit list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command lists all or some of the circuits the local node is a member of.
+This command displays abbreviated information pertaining to circuits in columns,
+with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it possible to
+verify that circuits have been successfully created as well as being able to
+access the generated circuit ID assigned to a circuit. The information displayed
+will be the same for all member nodes. The circuits listed have been accepted by
+all members.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-f`, `--format` FORMAT
+: Specifies the output format of the circuit. (default `human`). Possible values
+  for formatting are `human` and `csv`.
+
+`-m`, `--member` <member>
+: Filter the circuits list by a node ID that is present in the circuits’ members
+  list.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+This command displays information about circuits with a default `human`
+formatting, meaning the information is displayed in a table. The `--member` option
+allows for filtering the circuits.
+
+The following command does not specify any filters, therefore all circuits
+the local node, `alpha-node-000` is a member of are displayed.
+```
+$ splinter circuit list \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+```
+
+The next command specifies a `--member` filter, therefore all circuits
+the local node, `alpha-node-000` is a part of including the `gamma-node-000` node
+ID will be listed.
+```
+$ splinter circuit list \
+  member gamma-node-000 \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+```
+
+Since all of the circuits listed have been accepted by each member, the same
+circuit information will be displayed for member nodes.
+
+From the perspective of the `gamma-node-000` node, this command will display the
+following with no filters:
+```
+$ splinter circuit list \
+  --url URL-of-gamma-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+```
+
+From the perspective of the `beta-node-000` node, this command will display the
+following with no filters:
+```
+$ splinter circuit list \
+  --url URL-of-gamma-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-proposals.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-proposals.1.md
@@ -1,0 +1,108 @@
+% SPLINTER-CIRCUIT-PROPOSALS(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-proposals** — Lists the current circuit proposals
+
+SYNOPSIS
+========
+**splinter circuit proposals** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Lists all of the circuit proposals that the local node is a proposed member of.
+This command displays abbreviated information pertaining to proposed circuits in
+columns, with the headers `ID`, `MANAGEMENT` and `MEMBERS`. This makes it possible
+to verify that circuit proposals have been successfully proposed as well as being
+able to access the generated circuit ID assigned to a proposal. Circuit proposals
+have not necessarily been voted on by all proposed members.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-f`, `--format` FORMAT
+: Specifies the output format of the circuit proposal. (default `human`).
+  Possible values for formatting are `human` and `csv`. The `human` option
+  displays the circuit proposals information in a formatted table, while `csv`
+  prints the circuit proposals information via comma-separated values.
+
+`--management-type` MANAGEMENT-TYPE
+: Filter the circuit proposals by their circuit management type.
+
+`-m`, `--member` MEMBER
+: Filter the circuits list by a node ID that is present in the circuit proposal’s
+  members list.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+This command displays information about circuit proposals with a default `human`
+formatting, meaning the information is displayed in a table. The `--member` and
+`--management-type` options allow for filtering the circuit proposals.
+
+The following command does not specify any filters, therefore all circuit proposals
+the local node, `alpha-node-000` is a part of are displayed.
+```
+$ splinter circuit proposals \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+```
+
+The next command specifies a `--management-type` filter, therefore all circuit
+proposals the local node, `alpha-node-000` is a part of with a `circuit_management_type`
+of `mgmt001` will be listed.
+```
+$ splinter circuit proposals \
+  --management-type mgmt001 \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+01234-ABCDE   mgmt001       alpha-node-000;beta-node-000
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+```
+
+The next command specifies a `--member` filter, therefore all circuit proposals
+the local node, `alpha-node-000` is a part of including the `gamma-node-000` node
+ID will be listed.
+```
+$ splinter circuit proposals \
+  member gamma-node-000 \
+  --url URL-of-alpha-node-splinterd-REST-API
+ID            MANAGEMENT    MEMBERS
+43210-ABCDE   mgmt001       alpha-node-000;gamma-node-000
+56789-ABCDE   mgmt002       alpha-node-000;gamma-node-000
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-list(1)`
+| `splinter-circuit-vote(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-propose.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-propose.1.md
@@ -1,0 +1,189 @@
+% SPLINTER-CIRCUIT-PROPOSE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-propose** — Propose that a new circuit is created
+
+SYNOPSIS
+========
+**splinter circuit propose** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command submits a proposal to create a new Splinter circuit with one or more
+other nodes. When the other nodes receive this proposal, they vote to accept or
+reject it with `splinter circuit vote`. If all nodes accept the proposal, the
+circuit is created.
+
+It is necessary to specify the participating nodes for a circuit proposal as well
+as information for the intended use and operation of the circuit. Circuit proposals
+may be constructed multiple ways, via command-line options using this command or
+using the `splinter circuit template` command. The `splinter circuit template`
+command offers a partially completed circuit proposal, requiring less input than
+using `splinter circuit propose`. More information on how to use circuit templates
+can be found in the splinter-circuit-template(1) man page.
+
+FLAGS
+=====
+`-n`, `--dry-run`
+: Show the circuit definition without submitting the proposal
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`--comments COMMENTS`
+: Adds human-readable comments to the circuit proposal.
+
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file.
+
+`--management MANAGEMENT-TYPE`
+: Specifies the circuit management type. Circuit management type indicates the
+  application authorization handler which handles the circuit’s change proposals.
+
+`--metadata APPLICATION-METADATA` ...
+: Provides application-specific metadata for the circuit proposal. Repeat this
+  option to provide multiple entries for the application metadata.
+
+`--metadata-encoding METADATA-ENCODING`
+: Sets the encoding type for the application metadata (default: `string`).
+  Accepted values: `json`, `string`.
+
+`--node NODE-STRING` ...
+: Specifies a node that should be part of the circuit, using the format
+  `NODE-ID::ENDPOINT1,ENDPOINT2`. All endpoints must be in the registry entry
+  for the given node ID. The proposer must also specify its own node, if it is
+  to be be included on the circuit proposal. Repeat this option to specify
+  multiple nodes.
+
+`--service SERVICE-STRING` ...
+: Specifies the service ID and allowed nodes, using the format
+  `SERVICE-ID::ALLOWED-NODES`. Service IDs are comprised of 4 ASCII alphanumeric
+  characters. The ALLOWED-NODES specifies the node which the service will run
+  on, currently only one node ID is allowed.
+
+`--service-arg SERVICE-ARGUMENTS` ...
+: Passes key/value arguments to the specified service (as defined by
+  `--service`), using the format `SERVICE-ID::KEY=VALUE`. Service arguments
+  provided must match those required to create the service. The glob operator,
+  `*`, may be used in place of the SERVICE-ID to match all or certain parts
+  of the 4 character SERVICE-ID. For instance, `AA*::KEY=VALUE` to match
+  all service IDs that begin with `AA`. Repeat this option to specify multiple
+  key/value arguments.
+
+`--service-peer-group SERVICE-PEER-GROUP` ...
+: Specifies the service peer group (a list of peer services). Peer services are
+  services used by peer nodes within a circuit. This is the group of services
+  that must come to consensus amongst the node peers. Repeat this option to
+  specify multiple service peer groups.
+
+`--service-type SERVICE-TYPE` ...
+: Provides a service type for the specified service (as defined by
+  `--service`), using the format `SERVICE-ID::SERVICE-TYPE`. The glob operator,
+  `*`, may be used in place of the SERVICE-ID to match all or certain parts
+  of the 4 character SERVICE-ID. For instance, `AA*::SERVICE-TYPE` to match
+  all service IDs that begin with `AA`. Scabbard is a  Splinter service currently
+  implemented to be used, that can be specified with `service-type` of `scabbard`.
+  Repeat this option to specify multiple service types.
+
+`--template TEMPLATE`
+: Specifies a template to use for defining the circuit. Additional information
+  on circuit templates can be found in the splinter-circuit-template(1) man page.
+
+`--template-arg TEMPLATE-ARG` ...
+: Provides a key/value argument for the circuit template (as specified by
+  `--template``), using the format `KEY=VALUE`. Repeat this option to
+  specify multiple template arguments.
+
+`-U`, `--url URL`
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+EXAMPLES
+========
+This command proposes a simple circuit with one other node.
+
+* The proposing node has ID `alpha001` and endpoint `tcps://splinterd-node-acme001:8044`.
+* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`
+  and `tcp://splinterd-node-beta001:8045`.
+* There is one service with ID `AA01`. This service has no service
+  arguments, service type, or service group.
+
+```
+$ splinter circuit propose \
+  --node alpha001::tcps://splinterd-node-alpha001:8044 \
+  --node beta001::tcps://splinterd-node-beta001:8044,tcp://splinterd-node-beta001:8045 \
+  --service AA01::alpha001 \
+  --key PRIVATE-KEY-FILE
+  --url URL-of-splinterd-REST-API
+```
+
+The next command proposes a circuit with one other node, with multiple services
+and multiple service-args.
+
+* The proposing node has ID `alpha001` and endpoint `tcps://splinterd-node-alpha001:8044`.
+* The other node has ID `beta001` and endpoint `tcps://splinterd-node-beta001:8044`.
+* There are two services for each member node with a `service-type` of `scabbard`
+  for each. The service ID for the alpha node service is `AA01` and the
+  beta node service ID is `BB01`. Each of these services are specified
+  in the service group by providing each service ID for the `service-peer-group`
+  argument. There is also a service-arg for the `AA01`, the `admin_keys`
+  which is required by the Splinter Scabbard service.
+
+```
+splinter circuit propose \
+  --key PRIVATE-KEY-FILE \
+  --url URL-of-splinterd-REST-API \
+  --node alpha001::tcps://splinterd-node-alpha001:8044 \
+  --node beta001::tcps://splinterd-node-beta001:8044 \
+  --service AA01::alpha-node-001 \
+  --service BB01::beta-node-001 \
+  --service-type AA01::scabbard \
+  --service-type BB01::scabbard \
+  --service-arg AA01::admin_keys=NODE-PUBLIC-KEY \
+  --service-arg BB01::admin_keys=NODE-PUBLIC-KEY \
+  --service-peer-group AA01,BB01
+```
+
+The glob operator, `*` may be used to match SERVICE-ID for the `--service-type`
+and `--service-arg` arguments. Therefore, this part of the command:
+
+```
+--service-type AA01::scabbard \
+--service-type BB01::scabbard \
+--service-arg AA01::admin_keys=NODE-PUBLIC-KEY \
+--service-arg BB01::admin_keys=NODE-PUBLIC-KEY \
+```
+
+becomes the following using the glob operator:
+```
+--service-type *::scabbard \
+--service-arg *::admin_keys=NODE-PUBLIC-KEY \
+```
+
+SEE ALSO
+========
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-template(1)`
+| `splinter-circuit-vote(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-show.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-show.1.md
@@ -1,0 +1,107 @@
+% SPLINTER-CIRCUIT-SHOW(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-show** — Displays information about a circuit
+
+SYNOPSIS
+========
+**splinter circuit show** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT
+
+DESCRIPTION
+===========
+Display the entire definition of a circuit or proposal that the node is a member
+or proposed member of. All members, or proposed members, may view the circuit
+definition. Viewing a proposed circuit enables nodes to view information pertaining
+to other proposed member nodes as well as the status of a node’s vote regarding
+the circuit. The proposed circuit will be viewable unless any proposed member nodes
+reject the circuit proposal.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-f`, `--format` FORMAT
+: Specifies the output format of the circuit proposal. (default `human`).
+  Possible values for formatting are `human` and `csv`.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+
+ARGUMENTS
+=========
+`CIRCUIT`
+: Specify the circuit ID of the circuit to be shown.
+
+EXAMPLES
+========
+This command displays information about a circuit with the default `human`
+formatting, which intends to use indentation and labels to make the circuit
+information understandable.
+
+* The proposing node has ID `alpha001` and endpoint
+  `tcps://splinterd-node-alpha001:8044`, and a service ID of `AA01`.
+* The proposed member node has ID `beta001` and endpoint
+  `tcps://splinterd-node-beta001:8044`, and a service ID of `BB01`.
+* The command shows a circuit that was proposed by node alpha001 but has yet to
+  be voted on by beta001, with a circuit ID of `01234-ABCDE`.
+
+The information displayed below will appear the same on all proposed member nodes.
+If all member nodes vote to accept the circuit, the `splinter-circuit-show`
+command will display the same information, without the `Vote` as all nodes would
+have accepted the proposal. If any of the member nodes vote to reject the circuit,
+the proposal will not be viewable by any nodes.
+
+```
+$ splinter circuit show 01234-ABCDE \
+  ---url URL-of-alpha-node-splinterd-REST-API
+Proposal to create: 01234-ABCDE
+    Management Type: mgmt001
+
+    alpha-001 (tcps://splinterd-node-alpha001:8044)
+        Vote: ACCEPT (implied as requester):
+            ALPHA-PUBLIC-KEY
+        Service: AA01
+            admin_keys:
+                ALPHA-PUBLIC-KEY
+            peer_services:
+                BB01
+
+    beta-001 (tcps://splinterd-node-beta001:8044)
+        Vote: PENDING
+        Service: AA01
+            admin_keys:
+                ALPHA-PUBLIC-KEY
+            peer_services:
+                AA01
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-list(1)`
+| `splinter-circuit-proposals(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-template-arguments.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-template-arguments.1.md
@@ -1,0 +1,70 @@
+% SPLINTER-CIRCUIT-TEMPLATE-ARGUMENTS(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-arguments** — Displays the arguments defined in a
+circuit template
+
+SYNOPSIS
+========
+**splinter circuit template arguments** \[**FLAGS**\] TEMPLATE-NAME
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. Circuit template arguments are required when
+building a circuit from the template. This command lists the arguments that are
+defined in the specified circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+ARGUMENTS
+=========
+`TEMPLATE-NAME`
+: Circuit template that contains the arguments of interest.
+
+EXAMPLES
+========
+The following command shows the arguments for the `scabbard` circuit template,
+which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template arguments scabbard
+
+name: admin_keys
+required: false
+default_value: $(a:SIGNER_PUB_KEY)
+description: Public keys used to verify transactions in the scabbard service
+
+name: nodes
+required: true
+default_value: Not set
+description: List of node IDs
+
+name: signer_pub_key
+required: false
+default_value: Not set
+description: Public key of the signer
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-list(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-template-list.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-template-list.1.md
@@ -1,0 +1,56 @@
+% SPLINTER-CIRCUIT-TEMPLATE-LIST(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-list** — Displays all available circuit templates
+
+SYNOPSIS
+========
+**splinter circuit template list** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. This command lists all available circuit
+templates.
+
+A Scabbard circuit template is available by default (this template is packaged
+with the Splinter CLI).
+
+Tip: Use the `splinter circuit template arguments` command to see the required
+arguments for a specific circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+EXAMPLES
+========
+The following example lists the circuit templates on a system that has only the
+`scabbard` template, which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template list
+Available templates:
+scabbard
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-template-show.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-template-show.1.md
@@ -1,0 +1,79 @@
+% SPLINTER-CIRCUIT-TEMPLATE-SHOW(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template-show** — Displays the details of a circuit template
+
+SYNOPSIS
+========
+**splinter circuit template show** \[**FLAGS**\] TEMPLATE-NAME
+
+DESCRIPTION
+===========
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. This command displays the entire template
+definition, including the arguments and rules, for the specified template.
+
+Tip: Use the `splinter circuit template arguments` command to show only the
+required arguments for a specific circuit template.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+ARGUMENTS
+=========
+`TEMPLATE-NAME`
+: Circuit template to be displayed.
+
+EXAMPLES
+========
+The following command shows the details of the `scabbard` circuit template,
+which is available by default (packaged with the Splinter CLI).
+
+```
+$ splinter circuit template show scabbard
+---
+version: v1
+args:
+  - name: “$(a:ADMIN_KEYS)”
+    required: false
+    default: “$(a:SIGNER_PUB_KEY)”
+    description: Public keys used to verify transactions in the scabbard service
+  - name: “$(a:NODES)”
+    required: true
+    description: List of node IDs
+  - name: “$(a:SIGNER_PUB_KEY)”
+    required: false
+    description: Public key of the signer
+rules:
+  create-services:
+    service-type: scabbard
+    service-args:
+      - key: admin_keys
+        value:
+          - "$(a:ADMIN_KEYS)"
+      - key: peer_services
+        value: "$(r:ALL_OTHER_SERVICES)"
+    first-service: a000
+```
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-list(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-template.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-template.1.md
@@ -1,0 +1,59 @@
+% SPLINTER-CIRCUIT-TEMPLATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-template** — Manage circuit templates
+
+SYNOPSIS
+========
+**splinter circuit template** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command provides subcommands to list the available circuit templates, display
+template details, and show the required arguments for a specific template.
+
+Circuit templates help simplify the process of creating new circuits with the
+`splinter circuit propose` command. A circuit template specifies the required
+arguments and rules for the circuit. Each template on the system must have a unique
+name.
+
+A Scabbard circuit template, named `scabbard`, is available by default (packaged
+with the Splinter CLI). This template can be used as a model for other circuit
+templates.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`arguments`
+: List arguments of a template.
+
+`list`
+: List available templates.
+
+`show`
+: Display a specific available template.
+
+SEE ALSO
+========
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-list(1)`
+| `splinter-circuit-template-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit-vote.1.md
+++ b/docs/0.4/references/cli/splinter-circuit-vote.1.md
@@ -1,0 +1,93 @@
+% SPLINTER-CIRCUIT-VOTE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit-vote** — Submits a vote to accept or reject a circuit proposal
+
+SYNOPSIS
+========
+**splinter circuit vote** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID --accept --reject
+
+DESCRIPTION
+===========
+Vote on a new circuit proposal by specifying the circuit ID of the circuit the node
+is voting on, as well as the flag to `--accept` or `--reject`. The generated ID of
+a proposed circuit can be viewed using the `splinter-circuit-proposals` command and
+this circuit ID is used to specify the circuit proposal being voted on. A circuit
+proposal is viewable, via the `splinter-circuit-proposals` or `splinter-circuit-show`
+commands, by all proposed member nodes unless a proposed member node votes to
+reject the circuit proposal. A circuit proposal needs to be voted on by all proposed
+members that did not propose the circuit in the first place. Circuit proposers have
+an assumed `ACCEPT` vote, as these nodes requested the creation of the circuit.
+
+FLAGS
+=====
+`--accept`
+: Accept the circuit proposal specified.
+
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`--reject`
+: Reject the circuit proposal specified.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be voted on.
+
+EXAMPLES
+========
+* The proposed circuit has ID `1234-ABCDE`.
+
+The following command displays a member node voting to accept the circuit proposal:
+```
+$ splinter circuit vote \
+  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-proposed-member-node-splinterd-REST-API \
+  1234-ABCDE \
+  --accept
+```
+
+The following command displays a member node voting to reject the circuit proposal:
+```
+$ splinter circuit vote \
+  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-proposed-member-node-splinterd-REST-API \
+  1234-ABCDE \
+  --reject
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-circuit.1.md
+++ b/docs/0.4/references/cli/splinter-circuit.1.md
@@ -1,0 +1,67 @@
+% SPLINTER-CIRCUIT(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-circuit** — Provides circuit management functionality.
+
+SYNOPSIS
+========
+**splinter circuit** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command allows nodes to create and manage circuits and circuit proposals.
+Commands to list and display circuits and circuit proposals that a node is a member
+of are also available subcommands. Nodes are also able to vote to accept or reject
+circuit proposals using the `splinter-circuit-vote` subcommand.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`default`
+: Manage default values for circuit creation.
+
+`list`
+: List all circuits that have been accepted by all proposed members.
+
+`proposals`
+: List all circuit proposals. Circuit proposals have not been voted on by all
+  proposed members.
+
+`propose`
+: Propose a new circuit to be created.
+
+`show`
+: Display a specific circuit or circuit proposal.
+
+`template`
+: Manage circuit templates used for circuit creation.
+
+`vote`
+: Vote on a new circuit proposal. Only the proposed members that did not propose
+  the circuit are able to vote on a circuit. The circuit requester has an assumed
+  vote of `ACCEPT`.
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-database-migrate.1.md
+++ b/docs/0.4/references/cli/splinter-database-migrate.1.md
@@ -1,0 +1,58 @@
+% SPLINTER-DATABASE-MIGRATE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-database-migrate** — Updates the Biome database for a new Splinter
+release
+
+SYNOPSIS
+========
+
+**splinter database migrate** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+Biome is the Splinter module that manages users, credentials, and private keys,
+using a PostgreSQL database to store this information.
+
+This command migrates the Biome database from one Splinter release to the next.
+If a new release adds new database tables or changes existing table formats,
+run this command to update the Biome database to the new format.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`-C` *CONNECTION-STRING*
+: Specifies the connection string or URI for the database server.
+
+EXAMPLES
+========
+This example migrates the Biome database by connecting to a PostgreSQL server
+with the example hostname and port `splinter-db-alpha:5432`.
+
+```
+splinter database migrate -C postgres://admin:admin@splinter-db-alpha:5432/splinter
+```
+
+SEE ALSO
+========
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter-database.1.md
+++ b/docs/0.4/references/cli/splinter-database.1.md
@@ -1,0 +1,49 @@
+% SPLINTER-DATABASE(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-database** — Provides database management functions for Biome
+
+SYNOPSIS
+========
+
+**splinter** **database** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+This command provides subcommands for working with the Biome database.
+(Biome provides user management functionality for Splinter applications.)
+For example, the `migrate` subcommand updates the Biome database to a
+new release.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decreases verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+
+`migrate`
+: Updates the Biome database for a new Splinter release
+
+SEE ALSO
+========
+| `splinter-database-migrate(1)`
+| 
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+

--- a/docs/0.4/references/cli/splinter-health-status.1.md
+++ b/docs/0.4/references/cli/splinter-health-status.1.md
@@ -1,0 +1,59 @@
+% SPLINTER-HEALTH-STATUS(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-health-status** — Displays information about a Splinter node
+
+SYNOPSIS
+========
+**splinter health status** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+**NOTE: Currently, this command does not display node information. Full
+functionality is planned in an upcoming release.**
+
+This command displays a Splinter node's version, endpoint, node ID, and the
+endpoints of its connected peers (other nodes on the same circuit or circuits
+as this node).
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`-U`, `--url URL`
+: Specifies the URL for the node of interest (the URL for the `splinterd`
+  REST API on the node). This option is required unless `$SPLINTER_REST_API_URL`
+  is set.
+
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-list(1)`
+| `splinter-circuit-show(1)`
+| 
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+

--- a/docs/0.4/references/cli/splinter-health.1.md
+++ b/docs/0.4/references/cli/splinter-health.1.md
@@ -1,0 +1,47 @@
+% SPLINTER-HEALTH(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-health** — Displays information about node and network health
+
+SYNOPSIS
+========
+
+**splinter** **health** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+
+SUBCOMMANDS
+===========
+
+`status`
+: Displays information about a Splinter node (version, endpoint, node ID,
+  and connected peers)
+
+SEE ALSO
+========
+| `splinter-health-status(1)`
+| 
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+

--- a/docs/0.4/references/cli/splinter-keygen.1.md
+++ b/docs/0.4/references/cli/splinter-keygen.1.md
@@ -1,0 +1,95 @@
+% SPLINTER-KEYGEN(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter-keygen** — Generates user and daemon keys for Splinter
+
+SYNOPSIS
+========
+
+**splinter keygen** \[**FLAGS**\] \[**OPTIONS**\] \[*KEY-NAME*\]
+
+DESCRIPTION
+===========
+
+This command generates secp256k1 public/private keys for Splinter.
+
+If no option is specified, this command generates user keys that are stored in
+the directory `$HOME/splinter/keys`. The `--system` flag generates keys for the
+Splinter daemon (`splinterd`) that are stored in `/etc/splinter/keys`. The
+`--key-dir` option generates keys in the specified directory.
+
+The file names are determined by the user name, unless the `*KEY-NAME*` argument
+is used.
+
+FLAGS
+=====
+
+`-f`, `--force`
+: Overwrites key files if they already exist.
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decreases verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`--system`
+: Generates system keys for `splinterd` in `/etc/splinter/keys`.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`--key-dir DIRECTORY`
+: Generates keys in the given `DIRECTORY`, creating the directory if it does not
+  already exist.
+
+ARGUMENTS
+=========
+
+`*KEY-NAME*`
+: (Optional) Specifies the base name for the key files. By default, the user
+  name is used.
+
+EXAMPLES
+========
+
+This example generates user keys for a Splinter user who is logged in as
+`paulbunyan`.
+
+```
+$ splinter keygen
+writing file: "/Users/paulbunyan/splinter/keys/paulbunyan.priv"
+writing file: "/Users/paulbunyan/splinter/keys/paulbunyan.pub"
+```
+
+This example generates keys for the user `babe` in the `/tmp` directory:
+
+```
+$ splinter keygen --key-dir /tmp babe
+writing file: "/tmp/babe.priv"
+writing file: "/tmp/babe.pub"
+```
+
+The next example generates system keys for the Splinter daemon, but specifies
+`splinterd` as the base name for the files (instead of the user name).
+
+```
+$ splinter keygen --system splinterd
+writing file: "/etc/splinter/keys/splinterd.priv"
+writing file: "/etc/splinter/keys/splinterd.pub"
+```
+
+SEE ALSO
+========
+
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/docs/0.4/references/cli/splinter.1.md
+++ b/docs/0.4/references/cli/splinter.1.md
@@ -1,0 +1,98 @@
+% SPLINTER(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinter** — Command-line interface for Splinter
+
+SYNOPSIS
+========
+
+**splinter** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+The `splinter` utility is the command-line interface for Splinter, a
+privacy-focused platform for distributed applications. This CLI provides a
+unified tool for creating circuits, generating keys, and other functions for
+managing a Splinter node.
+
+* Run `splinter --help` to see the list of subcommands.
+
+* Run `splinter *SUBCOMMAND* --help` to see information about a specific
+  subcommand (for example, `splinter circuit vote --help`).
+
+* To view the man page for a Splinter subcommand, use the "dashed form" of the
+  name, where each space is replaced with a hyphen. For example, run
+  `man splinter-circuit-list` to see the man page for `splinter circuit list`.
+
+SUBCOMMANDS
+===========
+
+`cert`
+: Generates insecure certificates for development with the `generate`
+  subcommand
+
+`circuit`
+: Provides circuit creation and management functions with `list`, `propose`,
+  `template`, `vote`, and other subcommands
+
+`database`
+: Provides database functions with the `migrate` subcommand
+
+`health`
+: Displays information about network health with the `status` subcommand
+
+`keygen`
+: Generates secp256k1 public/private keys
+
+`registry`
+: Provides commands to create and manage Splinter registry information.
+
+FLAGS
+=====
+
+Most `splinter` subcommands accept the following common flags:
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Do not display output
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of `-q`). Specify multiple times for more
+  output.
+
+ENVIRONMENT VARIABLES
+=====================
+
+Many `splinter` subcommands accept the following environment variable:
+
+**`SPLINTER_REST_API_URL`**
+: Specifies the endpoint for the Splinter daemon (`splinterd`)
+  if `-U` or `--url` is not used.
+
+SEE ALSO
+========
+| `splinter-cert-generate(1)`
+| `splinter-circuit-list(1)`
+| `splinter-circuit-proposals(1)`
+| `splinter-circuit-propose(1)`
+| `splinter-circuit-show(1)`
+| `splinter-circuit-template-arguments(1)`
+| `splinter-circuit-template-list(1)`
+| `splinter-circuit-template-show(1)`
+| `splinter-circuit-vote(1)`
+| `splinter-database-migrate(1)`
+| `splinter-health-status(1)`
+| `splinter-keygen(1)`
+| 
+| `splinterd(1)`
+| 
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md
+

--- a/docs/0.4/references/cli/splinterd.1.md
+++ b/docs/0.4/references/cli/splinterd.1.md
@@ -1,0 +1,375 @@
+% SPLINTERD(1) Cargill, Incorporated | Splinter Commands
+
+NAME
+====
+
+**splinterd** — Starts the Splinter daemon
+
+SYNOPSIS
+========
+
+**splinterd** \[**FLAGS**\] \[**OPTIONS**\] <arguments>
+
+DESCRIPTION
+===========
+
+This command configures and runs the Splinter daemon, `splinterd`. This daemon
+provides core Splinter functionality such as circuit management, a REST API,
+and an admin service. It can also include application-specific services.
+
+The `splinterd` command requires a new ID for the node. Other settings are
+optional.
+
+**Configuration File**
+
+This command provides the `-c` and `--config` options to specify an optional
+TOML configuration file containing `splinterd` settings, instead of using
+command-line options. (Any options on the command line will override those in
+the configuration file.) The file name must end with a `.toml` extension, such
+as `splinterd.toml`). For examples, see
+[splinterd/packaging/splinterd.toml.example](https://github.com/Cargill/splinter/blob/0-4/splinterd/packaging/splinterd.toml.example)
+and
+[splinterd/sample_configs](https://github.com/Cargill/splinter/tree/0-4/splinterd/sample_configs)
+in the `splinter` repository.
+
+**Connection Types**
+
+The Splinter daemon supports transport-level connections with raw (TCP),
+Transport Layer Security (TLS), and WebSocket protocols, which are also called
+"transport types". A node can use multiple transport types at once. By default,
+`splinterd` configures all transport types. If the `--no-tls` flag is set, no
+TLS connections are configured.
+
+
+TLS requires certificate authority (CA) certificates and keys, which are stored
+in `/etc/splinter/certs/` by default. If necessary, you can change the
+directory, specify individual file paths and names, or use self-signed
+(insecure) certificates in a development environment. For more information, see
+the certificate-related options and CERTIFICATE FILES, below.
+
+**Directory Locations**
+
+This command includes several options that change default Splinter directory
+locations. These directory locations can also be changed with environment
+variables or settings in the `splinterd` TOML configuration file. For more
+information, see `--config-dir`, `--storage` `--tls-cert-dir`, and
+"SPLINTER DIRECTORY PATHS", below.
+
+FLAGS
+=====
+
+`--enable-biome`
+: Enable the Biome subsystem, which provides user management functions for
+  Splinter applications. The `--database` option is required when this flag is
+  used.
+
+`-h`, `--help`
+: Prints help information.
+
+`--no-tls`
+: Turns off TLS configuration and restricts `splinterd` to TCP (`raw`)
+  connections. This flag allows `splinterd` to start without the certificates
+  and keys that TLS requires. Without `--no-tls`, if `splinterd` cannot find the
+  certificates and keys required by TLS, it exits with an error.
+
+`--tls-insecure`
+: Turns off certificate authority validation for TLS connections; all peer
+  certificates are accepted. This flag is intended for development environments
+  using self-signed certificates.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity. Specify multiple times for more output.
+
+OPTIONS
+=======
+
+`--admin-timeout TIMEOUT`
+: Sets the coordinator timeout, in seconds, for admin service proposals.
+  (Default: 30 seconds.)
+
+  This setting affects consensus-related activities for pending circuit changes
+  (functions that use the two-phase commit agreement protocol in the Scabbard
+  service).
+
+`--advertised-endpoints` `ADVERTISED-ENDPOINT`
+: Specifies the public network endpoint for daemon-to-daemon communication
+  between Splinter nodes, if the network endpoint is not public. Use the format
+  `tcp://ip:port`. (Default: Same as the network endpoint; see
+  `-n`, `--network-endpoints`.)
+
+  Specify multiple endpoints in a comma-separated list or with separate
+  `--advertised-endpoint` options.
+
+`-c`, `--config` `CONFIG-FILE`
+: Specifies the path and file name for a `splinterd` configuration file, which
+  is a TOML file that contains `splinterd` settings. (The file name must end
+  with a `.toml` extension.) For examples, see
+  [splinterd/packaging/splinterd.toml.example](https://github.com/Cargill/splinter/blob/0-4/splinterd/packaging/splinterd.toml.example)
+  and
+  [splinter/splinterd/sample_configs](https://github.com/Cargill/splinter/tree/0-4/splinterd/sample_configs)
+  in the `splinter` repository.
+
+  Any options on the command line will override the settings in the
+  configuration file.
+
+`--config-dir CONFIG-DIR`
+: Specifies the directory containing Splinter configuration files. (Default:
+  `/etc/splinter`, unless `SPLINTER_CONFIG_DIR` or `SPLINTER_HOME` is set.)
+
+`--display-name DISPLAY-NAME`
+: Specifies a human-readable name for the node (Default: "Node NODE-ID")
+
+`--database DB-URL`
+: Specifies the URL for the PostgreSQL database used for Biome. (Default:
+  127.0.0.1:5432.) This option is required when `--enable-biome` is used.
+
+`--heartbeat SECONDS`
+: Specifies how often, in seconds, to send a heartbeat. (Default: 30 seconds.)
+  Use 0 to turn off the heartbeat.
+
+  This heartbeat is used to check the health of connections to other Splinter
+  nodes.
+
+`-n`, `--network-endpoints` `NETWORK-ENDPOINT`
+: Specifies the endpoint for daemon-to-daemon communication between Splinter
+  nodes, using the format `protocol_prefix://ip:port`.
+  (Default: tcps://127.0.0.1:8044.)
+
+  Specify multiple endpoints in a comma-separated list or with separate
+  `-n` or `--network-endpoint` options.
+
+  `--node-id NODE-ID`
+: (Required) Sets a new ID for the node. The node ID must be unique across the
+  network (for all Splinter nodes that could participate on the same circuit).
+
+`--peers PEER-URL` `[,...]`
+: Specifies one or more Splinter nodes that `splinterd` will automatically
+  connect to when it starts. The *PEER-URL* argument must specify another node's
+  network endpoint, using the format `protocol_prefix://ip:port`.
+
+  Specify multiple nodes in a comma-separated list or by repeating the
+  `--peers` option. The protocol prefix part of the peer URL specifies the
+  type of connection that is created.
+
+`--registries REGISTRY-FILE` `[,...]`
+: Specifies one or more read-only Splinter registry files.
+
+`--registry-auto-refresh SECONDS`
+: Specifies how often, in seconds, to fetch remote node registry changes in the
+  background. (Default: 600 seconds.) Use 0 to turn off automatic refreshes.
+
+`--registry-forced-refresh SECONDS`
+: Specifies how often, in seconds, to fetch remote node registry changes on
+  read. (Default: 10 seconds.) Use 0 to turn off forced refreshes.
+
+`--rest-api-endpoint REST-API-ENDPOINT`
+: Specifies the connection endpoint for the REST API. (Default: 127.0.0.1:8080.)
+
+`--state-dir STATE-DIR`
+: Specifies the storage directory.
+  (Default: `/var/lib/splinter`.)
+
+  This option overrides the `SPLINTER_STATE_DIR` environment variable, if set.
+
+`--storage STORAGE-TYPE`
+: Specifies whether to store circuit state in memory or in a local YAML file.
+  *STORAGE-TYPE* can be `memory` or `yaml` (the default). For `yaml`, the file
+  is stored in the default state directory, `/var/lib/splinter`, unless
+  `SPLINTER_STATE_DIR` or `SPLINTER_HOME` is set.
+
+  Using `memory` for storage means that circuits will not persist when
+  `splinterd` restarts.
+
+`--tls-ca-file CERT-FILE`
+: Specifies the path and file name for the trusted CA certificate.
+  (Default: `/etc/splinter/certs/ca_pem`.)
+
+  Do not use this option with the `--tls-insecure` flag.
+
+`--tls-cert-dir CERT-DIR`
+: Specifies the directory that contains the trusted CA certificates and
+  associated key files. (Default: `/etc/splinter/certs/`, unless
+  `SPLINTER_CERT_DIR` or `SPLINTER_HOME` is set).
+
+`--tls-client-cert CERT-FILE`
+: Specifies the path and file name for the client certificate, which is
+  used by `splinterd` when it is sending messages over TLS. (Default:
+  `/etc/splinter/certs/client.crt`.)
+
+`--tls-client-key CLIENT-KEY`
+: Specifies the path and file name for the client key.
+  (Default: `/etc/splinter/certs/client.key`.)
+
+`--tls-server-cert SERVER-CERT`
+: Specifies the path and file name for the server certificate, which is used by
+  `splinterd` when it is receiving messages over TLS.
+  (Default: `/etc/splinter/certs/server.crt`.)
+
+`--tls-server-key SERVER-KEY`
+: Specifies the path and file name for the server key.
+  (Default: `/etc/splinter/certs/server.key`.)
+
+`--whitelist WHITELIST` `[,...]`
+: Lists one or more trusted domains for cross-origin resource sharing (CORS).
+  This option allows the specified domains to access restricted web resources
+  in a Splinter application.  If this option is not specified, all domains will
+  be allowed to access Splinter web resources.
+
+  Specify multiple domains in a comma-separated list or with separate
+  `--whitelist` options.
+
+CERTIFICATE FILES
+=================
+
+When the Splinter daemon runs in TLS mode (using `tcps` connections at the
+transport layer), it requires certificate authority (CA) certificates and
+associated keys that are stored in `/etc/splinter/certs/` by default
+(or `$SPLINTER_HOME/certs` if that environment variable is set).
+
+You can change the certificate directory by using the `--tls-cert-dir` option,
+setting the `SPLINTER_CERT_DIR` environment variable, or specifying the
+location in a `splinterd` configuration file.
+
+By default, the following file names are used for the certificates and
+associated keys:
+
+* `ca.pem`
+* `client.crt`
+* `client.key`
+* `server.crt`
+* `server.key`
+
+You can specify different paths and file names with the `--tls-ca-file`,
+`--tls-client-cert`, `--tls-client-key`, `--tls-server-cert`, and
+`--tls-server-key` options (or related settings in the configuration file).
+
+In a development environment, you can use the `--tls-insecure` flag to use
+self-signed certificates and keys (which can be generated by the
+`splinter cert generate` command). For more information, see
+"[Generating Insecure Certificates for
+Development](https://github.com/Cargill/splinter-docs/blob/master/docs/howto/generating_insecure_certificates_for_development.md)"
+in the Splinter documentation.
+
+SPLINTER DIRECTORY PATHS
+========================
+
+Several Splinter directories have the following default locations:
+
+* Splinter configuration directory: `/etc/splinter`
+
+* State directory: `/var/lib/splinter/`
+
+* TLS certificate directory: `/etc/splinter/certs/`
+
+For the configuration and certificate directories, the directory paths can be
+changed individually with a `splinterd` option, a setting in a TOML config file,
+or an environment variable. (The state directory location is controlled only by
+an environment variable when the default YAML storage type is used; no config
+setting or command option is available.) For more information, see
+`--config-dir`, `--storage` and `--tls-cert-dir`.
+
+In addition, the `SPLINTER_HOME` environment variable provides a simple way to
+change the base path for all of these directories. This variable is intended for
+development and testing. When `SPLINTER_HOME` is set, the default directory
+paths are:
+
+* Splinter configuration directory: `$SPLINTER_HOME/etc/`
+
+* State directory: `$SPLINTER_HOME/data/`
+
+* TLS certificate directory: `$SPLINTER_HOME/certs/`
+
+For example, if `SPLINTER_HOME` is set to `/tmp/testing`, the default path for
+the Splinter state directory is `/tmp/testing/data/`.
+
+Note: If an individual environment variable is set, it overrides the value in
+`SPLINTER_HOME` (if also set) for that directory. For example, `SPLINTER_HOME`
+is set to `/tmp/testing` and `SPLINTER_STATE_DIR` is set to
+`/tmp/splinter/state`, the Splinter state directory is `/tmp/splinter/state`.
+
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_CERT_DIR**
+: Specifies the directory containing certificate and associated key files.
+  (See `--tls-cert-dir`.)
+
+**SPLINTER_CONFIG_DIR**
+: Specifies the directory containing configuration files.
+  (See: `--config-dir`.)
+
+**SPLINTER_HOME**
+: Changes the base directory path for the Splinter directories, including the
+  certificate directory. See the "SPLINTER DIRECTORY PATHS" for more
+  information.
+
+  This value is not used if an environment variable for a specific directory
+  is set (`SPLINTER_CERT_DIR`, `SPLINTER_CONFIG_DIR`, or `SPLINTER_STATE_DIR`).
+
+**SPLINTER_STATE_DIR**
+: Specifies where to store the circuit state YAML file, if `--storage` is
+  set to `yaml`. (See `--storage`.) By default, this file is stored in
+  `/var/lib/splinter`.
+
+**SPLINTER_STRICT_REF_COUNT**
+: Turns on strict peer reference counting. If `SPLINTER_STRICT_REF_COUNT`is set
+  to `true` and the peer manager tries to remove a peer reference that does not
+  exist, the Splinter daemon will panic. By default, the daemon does not panic
+  and instead logs an error. This environment variable is intended for
+  development and testing.
+
+FILES
+=====
+
+`/etc/splinter/`
+: Default location for the Splinter configuration directory. Note: If
+  `$SPLINTER_HOME` is set, the default location is `$SPLINTER_HOME/etc/`.
+
+`/etc/splinter/certs/`
+: Default location for the TLS certificate directory, which stores CA
+  certificates and the associated keys. Note: If `SPLINTER_HOME` is set, the
+  default location is `$SPLINTER_HOME/certs/`.
+
+`/var/lib/splinter/`
+: Default location for the Splinter state directory, which stores the circuit
+  state YAML file (unless `--storage` is set to `memory`). Note: If
+  `$SPLINTER_HOME` is set, the default location is `$SPLINTER_HOME/data/`.
+
+EXAMPLES
+========
+
+To run `splinterd` using the default settings, specify a new, unique node ID.
+Replace the example value with the ID for your node.
+
+```
+$ splinterd --node-id mynode
+```
+
+To specify a configuration file instead of command-line options, use the
+`-c` or `--config` option.
+
+```
+$ splinterd --config ./configs/splinterd-mynode.toml
+```
+
+In this example, the configuration file specifies the node ID and increases
+the heartbeat interval to 60 seconds.
+
+```
+# Friendly identifier for this node. Must be unique on the network.
+node_id = "mynode"
+
+# The number of seconds between network keep-alive heartbeat messages.
+# Setting heartbeat to 0 disables this feature.
+heartbeat = 60
+```
+
+SEE ALSO
+========
+| `splinter-circuit-propose(1)`
+| `splinter-cert-generate(1)`
+|
+| Splinter documentation: https://github.com/Cargill/splinter-docs/blob/master/docs/index.md

--- a/justfile
+++ b/justfile
@@ -1,0 +1,41 @@
+# Copyright 2018-2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+splinter_repo := "../splinter"
+
+copy-docs:
+    #!/usr/bin/env sh
+    set -e
+    if test -f {{splinter_repo}}/VERSION; then
+        version=$(cat {{splinter_repo}}/VERSION | awk -F. '{print $1"."$2}')
+        # Print the branch of splinter the man pages are from
+        splinter_branch=$(cd {{splinter_repo}} && git name-rev --name-only HEAD)
+        echo "Splinter repository branch is $splinter_branch"
+
+        # sync man pages from splinter cli and splinterd
+        cmd="rsync -r -v {{splinter_repo}}/cli/man/ docs/$version/references/cli"
+        echo "\033[1m$cmd\033[0m"
+        $cmd
+
+        cmd="rsync -r -v {{splinter_repo}}/splinterd/man/ docs/$version/references/cli"
+        echo "\033[1m$cmd\033[0m"
+        $cmd
+
+        # Remove any templates that were copied over
+        cmd="rm -v docs/$version/references/cli/*.example"
+        echo "\033[1m$cmd\033[0m"
+        $cmd
+    else
+        echo "{{splinter_repo}}/VERSION was not found, cannot copy man pages"
+    fi


### PR DESCRIPTION
This function assumes that your directory structure has
splinter and splinter-docs at the same level by default. Running
`just` or `just copy-docs` will rsync the man pages files
from splinter cli and splinterd to docs/VERSION/references/cli where
the version of the docs is taking from splinter/VERSIONS file.

The location of the splinter repo can be changed by running

`just --set splinter_repo PATH`

Also updates and adds new man pages from splinter 0-4 branch. To use this script right now requires manually updating the VERSION in the splinter repo on the 0-4 branch so it is 0.4.x instead of 0.3.19