### PR TITLE
Reformat CLI Command Reference page

### DIFF
--- a/docs/0.4/references/cli/cli_command_reference.md
+++ b/docs/0.4/references/cli/cli_command_reference.md
@@ -1,29 +1,74 @@
 # CLI Command Reference
 
+## splinter CLI
 The `splinter` command-line interface (CLI) provides a set of commands to
-interact with Splinter components:
+interact with Splinter components.
 
-  * [splinter](splinter.1.md)
-  * [splinter cert](splinter-cert.1.md)
-  * [splinter cert generate](splinter-cert-generate.1.md)
-  * [splinter circuit](splinter-circuit.1.md)
-  * [splinter circuit list](splinter-circuit-list.1.md)
-  * [splinter circuit proposals](splinter-circuit-proposals.1.md)
-  * [splinter circuit propose](splinter-circuit-propose.1.md)
-  * [splinter circuit show](splinter-circuit-show.1.md)
-  * [splinter circuit template](splinter-circuit-template.1.md)
-  * [splinter circuit template
-    arguments](splinter-circuit-template-arguments.1.md)
-  * [splinter circuit template show](splinter-circuit-template-show.1.md)
-  * [splinter circuit template list](splinter-circuit-template-list.1.md)
-  * [splinter circuit vote](splinter-circuit-vote.1.md)
-  * [splinter database](splinter-database.1.md)
-  * [splinter database migrate](splinter-database-migrate.1.md)
-  * [splinter health](splinter-health.1.md)
-  * [splinter health status](splinter-health-status.1.md)
-  * [splinter keygen](splinter-keygen.1.md)
+[`splinter`](splinter.1.md)
+Command-line interface for Splinter
 
-  The `splinterd` command-line interface (CLI) provides the command for running
-  the Splinter daemon.
+### Certificate Management
+[`splinter cert`](splinter-cert.1.md)
+Provides certificate management subcommands
 
-  * [splinterd](splinterd.1.md)
+[`splinter cert generate`](splinter-cert-generate.1.md)
+Generates test certificates and keys for running splinterd with TLS (in insecure
+mode)
+
+### Circuit Management
+[`splinter circuit`](splinter-circuit.1.md)
+Provides circuit management functionality.
+
+[`splinter circuit list`](splinter-circuit-list.1.md)
+Displays the existing circuits for this Splinter node.
+
+[`splinter circuit proposals`](splinter-circuit-proposals.1.md)
+Lists the current circuit proposals.
+
+[`splinter circuit propose`](splinter-circuit-propose.1.md)
+Propose that a new circuit is created
+
+[`splinter circuit show`](splinter-circuit-show.1.md)
+Displays information about a circuit
+
+[`splinter circuit template`](splinter-circuit-template.1.md)
+ Manage circuit templates
+
+[`splinter circuit template
+arguments`](splinter-circuit-template-arguments.1.md)
+Displays the arguments defined in a circuit template
+
+[`splinter circuit template show`](splinter-circuit-template-show.1.md)
+Displays the details of a circuit template
+
+[`splinter circuit template list`](splinter-circuit-template-list.1.md)
+Displays all available circuit templates
+
+[`splinter circuit vote`](splinter-circuit-vote.1.md)
+Submits a vote to accept or reject a circuit proposal
+
+### Database Management Functions for Biome
+[`splinter database`](splinter-database.1.md)
+Provides database management functions for Biome
+
+[`splinter database migrate`](splinter-database-migrate.1.md)
+Updates the Biome database for a new Splinter release
+
+### Display information about node and network health
+[`splinter health`](splinter-health.1.md)
+Displays information about node and network health
+
+[`splinter health status`](splinter-health-status.1.md)
+Displays information about a Splinter node
+
+### Generates user and daemon keys for Splinter
+[`splinter keygen`](splinter-keygen.1.md)
+Generates user and daemon keys for Splinter
+
+## splinterd CLI
+
+The `splinterd` command-line interface (CLI) provides the command for running
+the Splinter daemon.
+
+[`splinterd`](splinterd.1.md)
+Starts the Splinter daemon


### PR DESCRIPTION
Adds headers for each subset of commands and
remove bullets. Also adds a short description to each
command. These descriptions are from their man page.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>