### PR TITLE
Add initial footer for splinter website

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,7 @@
+<div class="card-footer text-muted" id="footer">
+  <img src="/logos/svg/splinter_logos_fulllogo_fuchsiablack.svg" height="36">
+  <div>
+      <a href="https://github.com/Cargill/splinter">Github</a>
+  </div>
+  <a> Copyright 2018-2020 Cargill Incorporated </a>
+</div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -64,6 +64,11 @@ img {
     border-bottom: 2px solid var(--splinter-fuchsia);
 }
 
+/* Footer */
+#footer {
+  text-align: center;
+}
+
 /* Both Sidebars */
 
 .sidebar-col {


### PR DESCRIPTION
Note: Currently the footer does not stay on the bottom for very short pages, such as the current about Biome doc.