### PR TITLE
Change published docker image name

### DIFF
--- a/ci/publish-docker
+++ b/ci/publish-docker
@@ -15,5 +15,5 @@
 
 set -e
 
-docker build -t splintercommunity/splinter.dev -f ci/website.dockerfile .
-docker push splintercommunity/splinter.dev
+docker build -t splintercommunity/splinter-docs -f ci/website.dockerfile .
+docker push splintercommunity/splinter-docs

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ copy-docs:
 
 docker-build:
     docker build \
-        -t splintercommunity/splinter.dev \
+        -t splintercommunity/splinter-docs \
         -f ci/website.dockerfile \
         .
 


### PR DESCRIPTION
"splinter.dev" is easily confused with the "splinter-dev" image used as a
base image for splinter development.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>