### PR TITLE
Add Building Splinter topic to docs

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -31,7 +31,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>
-        <a href="https://github.com/Cargill/splinter/blob/master/README.md#building-splinter">Building Splinter</a>
+        <a href="/docs/0.4/howto/building_splinter.html">Building Splinter</a>
         <a href="/docs/0.4/howto/generating_insecure_certificates_for_development.html">Generating insecure certificates for development</a>
         <a href="/docs/0.4/howto/uploading_smart_contract.html">Uploading a smart contract</a>
     </div>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -31,7 +31,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>
-        <a href="https://github.com/Cargill/splinter/blob/master/README.md#building-splinter">Building Splinter</a>
+        <a href="/docs/0.5/howto/building_splinter.html">Building Splinter</a>
         <a href="/docs/0.5/howto/generating_insecure_certificates_for_development.html">Generating insecure certificates for development</a>
         <a href="/docs/0.5/howto/uploading_smart_contract.html">Uploading a smart contract</a>
     </div>

--- a/docs/0.4/howto/building_splinter.md
+++ b/docs/0.4/howto/building_splinter.md
@@ -1,0 +1,32 @@
+## Building Splinter
+
+The `splinter` repository is available at
+[github.com/Cargill/splinter](https://github.com/Cargill/splinter).
+
+To build Splinter, run `cargo build` from the root directory. This command
+builds all of the Splinter components, including `libsplinter` (the main
+library), `splinterd` (the splinter daemon), the CLI, the client, and all
+examples in the `examples` directory.
+
+To build individual components, run `cargo build` in the component directories.
+For example, to build only the splinter library, navigate to
+`libsplinter`, then run `cargo build`.
+
+To build Splinter using Docker, run
+`docker-compose -f docker-compose-installed.yaml build` from the root
+directory. This command builds Docker images for all of the Splinter
+components, including `libsplinter` (the main library), `splinterd`
+(the splinter daemon), the CLI, the client, and all examples in the `examples`
+directory.
+
+To build individual components using Docker, run
+`docker-compose -f docker-compose-installed.yaml build <component>`
+from the root directory. For example, to build only the splinter daemon,
+run `docker-compose -f docker-compose-installed.yaml build splinterd`.
+
+To use Docker to build Splinter with experimental features enabled, set an
+environment variable in your shell before running the build commands (for
+example: `export 'CARGO_ARGS=-- --features experimental'`). To go back to
+building with default features, unset the environment variable
+(`unset CARGO_ARGS`).
+

--- a/docs/0.5/howto/building_splinter.md
+++ b/docs/0.5/howto/building_splinter.md
@@ -1,0 +1,32 @@
+## Building Splinter
+
+The `splinter` repository is available at
+[github.com/Cargill/splinter](https://github.com/Cargill/splinter).
+
+To build Splinter, run `cargo build` from the root directory. This command
+builds all of the Splinter components, including `libsplinter` (the main
+library), `splinterd` (the splinter daemon), the CLI, the client, and all
+examples in the `examples` directory.
+
+To build individual components, run `cargo build` in the component directories.
+For example, to build only the splinter library, navigate to
+`libsplinter`, then run `cargo build`.
+
+To build Splinter using Docker, run
+`docker-compose -f docker-compose-installed.yaml build` from the root
+directory. This command builds Docker images for all of the Splinter
+components, including `libsplinter` (the main library), `splinterd`
+(the splinter daemon), the CLI, the client, and all examples in the `examples`
+directory.
+
+To build individual components using Docker, run
+`docker-compose -f docker-compose-installed.yaml build <component>`
+from the root directory. For example, to build only the splinter daemon,
+run `docker-compose -f docker-compose-installed.yaml build splinterd`.
+
+To use Docker to build Splinter with experimental features enabled, set an
+environment variable in your shell before running the build commands (for
+example: `export 'CARGO_ARGS=-- --features experimental'`). To go back to
+building with default features, unset the environment variable
+(`unset CARGO_ARGS`).
+


### PR DESCRIPTION
Initially, the content duplicates the "Building Splinter" section
in the splinter repo's README, with two changes:

- Added an intro sentence with a link to the splinter repo

- Fixed punctuation and parens in the last paragraph

Signed-off-by: Anne Chenette <chenette@bitwise.io>