### PR TITLE
Fix active link selection

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,23 +2,9 @@
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 <script src="/scripts/generateRightSidebar.js"></script>
-
-<script type="text/javascript">
-    $(document).ready(function () {
-        // Set the active links in the navbar, left sidebar, and left
-        // sidebar's version dropdown
-        $('.navbar-nav a').filter(function() {
-            return window.location.pathname.startsWith(this.getAttribute("href"));
-        }).addClass('active');
-        $('.left-sidebar-group a').filter(function() {
-            return window.location.pathname.startsWith(this.getAttribute("href"));
-        }).addClass('active');
-        $('#left-sidebar .dropdown-item').filter(function() {
-            return window.location.pathname.startsWith(this.getAttribute("href"));
-        }).addClass('active');
-    });
-</script>
+<script src="/scripts/activeLinks.js"></script>
 
 <script>
-   document.getElementById("right-sidebar").innerHTML = generateRightSidebar();
+    setActiveLinks();
+    document.getElementById("right-sidebar").innerHTML = generateRightSidebar();
 </script>

--- a/scripts/activeLinks.js
+++ b/scripts/activeLinks.js
@@ -1,0 +1,30 @@
+// Set the active links in the navbar, left sidebar, and left
+// sidebar's version dropdown
+function setActiveLinks() {
+    $(document).ready(function () {
+        var navbar_links = $('.navbar-nav a').filter(function() {
+            return window.location.pathname.startsWith(this.getAttribute("href"));
+        }).addClass('active');
+        $(getElementWithLongestPath(navbar_links)).addClass('active');
+
+        var left_sidebar_links = $('.left-sidebar-group a').filter(function() {
+            return window.location.pathname.startsWith(this.getAttribute("href"));
+        });
+        $(getElementWithLongestPath(left_sidebar_links)).addClass('active');
+
+        var dropdown_links = $('#left-sidebar .dropdown-item').filter(function() {
+            return window.location.pathname.startsWith(this.getAttribute("href"));
+        }).addClass('active');
+        $(getElementWithLongestPath(dropdown_links)).addClass('active');
+    });
+}
+
+function getElementWithLongestPath(elements) {
+    var longest_path = elements.get(0);
+    for (var i = 1; i < elements.length; i++) {
+        if (elements.get(i).getAttribute("href").length > longest_path.getAttribute("href").length) {
+            longest_path = elements.get(i);
+        }
+    }
+    return longest_path;
+}


### PR DESCRIPTION
Updates the JS code for setting the active links in the navbar and left
sidebar to account for overlapping paths. Also moves the code into a
function in its own JS script and calls the function from the `scripts`
include.

Signed-off-by: Logan Seeley <seeley@bitwise.io>