### PR TITLE
Add landing page for the REST API reference

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -39,6 +39,6 @@
         <div class="left-sidebar-header">Reference Guides</div>
         <a href="https://docs.rs/splinter">Splinter Rust API</a>
         <a href="/docs/0.4/references/cli/cli_command_reference.html">Splinter CLIs</a>
-        <a href="/docs/0.4/api/" target="_blank">Splinter REST API</a>
+        <a href="/docs/0.4/references/api/">Splinter REST API</a>
     </div>
 </div>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -39,6 +39,6 @@
         <div class="left-sidebar-header">Reference Guides</div>
         <a href="https://docs.rs/splinter">Splinter Rust API</a>
         <a href="/docs/0.5/references/cli/cli_command_reference.html">Splinter CLIs</a>
-        <a href="/docs/0.5/api/" target="_blank">Splinter REST API</a>
+        <a href="/docs/0.5/references/api/">Splinter REST API</a>
     </div>
 </div>

--- a/docs/0.4/references/api/index.md
+++ b/docs/0.4/references/api/index.md
@@ -1,0 +1,9 @@
+# Splinter REST API Reference
+
+This API defines the endpoints for the Splinter daemon, `splinterd`. These
+endpoints allow external applications to access Splinter functionality such as
+Biome user management, the Splinter registry, circuit proposals and management,
+smart contract functions with the scabbard service, and more.
+
+* [splinterd REST API Reference](https://www.splinter.dev/docs/0.4/api/)
+

--- a/docs/0.5/references/api/index.md
+++ b/docs/0.5/references/api/index.md
@@ -1,0 +1,9 @@
+# Splinter REST API Reference
+
+This API defines the endpoints for the Splinter daemon, `splinterd`. These
+endpoints allow external applications to access Splinter functionality such as
+Biome user management, the Splinter registry, circuit proposals and management,
+smart contract functions with the scabbard service, and more.
+
+* [splinterd REST API Reference](https://www.splinter.dev/docs/0.5/api/)
+


### PR DESCRIPTION
This change changes the Splinter REST API link in the left-nav TOC from an external link to a site-internal one.

Signed-off-by: Anne Chenette <chenette@bitwise.io>