### PR TITLE
Add landing page for the Rust API references

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -37,7 +37,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>
-        <a href="https://docs.rs/splinter">Splinter Rust API</a>
+        <a href="/docs/0.4/references/rust_api/">Splinter Rust API</a>
         <a href="/docs/0.4/references/cli/cli_command_reference.html">Splinter CLIs</a>
         <a href="/docs/0.4/api/" target="_blank">Splinter REST API</a>
     </div>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -37,7 +37,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Reference Guides</div>
-        <a href="https://docs.rs/splinter">Splinter Rust API</a>
+        <a href="/docs/0.5/references/rust_api/">Splinter Rust API</a>
         <a href="/docs/0.5/references/cli/cli_command_reference.html">Splinter CLIs</a>
         <a href="/docs/0.5/api/" target="_blank">Splinter REST API</a>
     </div>

--- a/docs/0.4/references/rust_api/index.md
+++ b/docs/0.4/references/rust_api/index.md
@@ -1,0 +1,15 @@
+# Rust API documentation
+
+Reference guides for Splinter's Rust APIs:
+
+* [splinter API Reference](https://docs.rs/splinter/0.4/):
+  Documentation for the `splinter` crate.
+
+* [scabbard API Reference](https://docs.rs/scabbard/0.4/):
+  Documentation for the `scabbard` crate. Scabbard is the service that runs
+  the Sabre smart contract engine.
+
+The crates are available at
+[crates.io/crates/splinter](https://crates.io/crates/splinter/0.4/)
+and [crates.io/crates/scabbard](https://crates.io/crates/scabbard/0.4/).
+

--- a/docs/0.5/references/rust_api/index.md
+++ b/docs/0.5/references/rust_api/index.md
@@ -1,0 +1,15 @@
+# Rust API documentation
+
+Reference guides for Splinter's Rust libraries:
+
+* [splinter API Reference](https://docs.rs/splinter/):
+  Documentation for the `splinter` library.
+
+* [scabbard API Reference](https://docs.rs/scabbard/):
+  Documentation for the `scabbard` library. Scabbard is the service that runs
+  the Sabre smart contract engine.
+
+The crates for these libraries are available at
+[crates.io/crates/splinter](https://crates.io/crates/splinter)
+and [crates.io/crates/scabbard](https://crates.io/crates/scabbard).
+


### PR DESCRIPTION
This PR eliminates an external link from the left-nav TOC.

Note: The v0.5 version of the splinter and scabbard crates (and docs) aren't
being published yet, so the 0.5 doc links go to the same docs.rs location as
the 0.4 links. A later PR will be needed once the crates (and docs) are versioned.

Signed-off-by: Anne Chenette <chenette@bitwise.io>