### PR TITLE
Remove anchor tags from markdown files

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,5 +6,5 @@
 
 <script>
     setActiveLinks();
-    document.getElementById("right-sidebar").innerHTML = generateRightSidebar();
+    generateRightSidebar();
 </script>

--- a/docs/0.4/howto/planning_splinter_deployment.md
+++ b/docs/0.4/howto/planning_splinter_deployment.md
@@ -143,7 +143,7 @@ this pattern has been tested with the Splinter examples.
 
 ![](../images/splinter-deployment-kubernetes.png "Splinter Kubernetes deployment")
 
-# Amazon EKS Deployment
+## Amazon EKS Deployment
 
 This example of Amazon EKS deployment uses a classic load balancer (CLB) as the
 ingress and Amazon Elastic Block Storage (EBS) as the backing store for

--- a/docs/0.4/howto/planning_splinter_deployment.md
+++ b/docs/0.4/howto/planning_splinter_deployment.md
@@ -9,19 +9,19 @@ Kubernetes Services (Amazon EKS).
 
 **Contents**
 <br>
-[Overview](#bookmark=id.ls4meksnxna)
+[Overview](#overview)
 <br>
-[Splinter Architecture](#bookmark=id.qwe1rp9mdlx5)
+[Splinter Architecture](#splinter-architecture)
 <br>
-[Network Configuration](#bookmark=id.brrcajnirna1)
+[Network Configuration](#network-configuration)
 <br>
-[Application Pattern](#bookmark=id.w243im9kbun8)
+[Application Pattern](#application-pattern)
 <br>
-[Docker Deployment](#bookmark=id.i8nr28r242j4)
+[Docker Deployment](#docker-deployment)
 <br>
-[Basic Kubernetes Deployment](#bookmark=id.4gmpe3v077wl)
+[Basic Kubernetes Deployment](#basic-kubernetes-deployment)
 <br>
-[Amazon EKS Deployment](#bookmark=id.ism06ku1ut2h)
+[Amazon EKS Deployment](#amazon-eks-deployment)
 
 ## Overview
 

--- a/docs/0.4/index.md
+++ b/docs/0.4/index.md
@@ -18,19 +18,19 @@ application interfaces, and transaction processing.
 
 This topic describes Splinter's key benefits:
 
-* [True privacy with circuits](#bookmark-private-circuits)
-* [Distributed ledger platform as a service](#bookmark-dl-service)
-* [Flexibility with Splinter's modular architecture](#bookmark-arch)
-* [Smart contracts that can share state](#bookmark-sm-share-state)
-* [Quick startup for application development](#bookmark-dev-startup)
-* [Event subscription for state changes](#bookmark-event-sub)
-* [Complex patterns for data flow](#bookmark-complex-data-flow)
-* [Auditable open source](#bookmark-open-source)
+* [True privacy with circuits](#true-privacy-with-circuits)
+* [Distributed ledger platform as a service](#distributed-ledger-platform-as-a-service)
+* [Flexibility with Splinter's modular architecture](#flexibility-with-splinters-modular-architecture)
+* [Smart contracts that can share state](#smart-contracts-that-can-share-state)
+* [Quick startup for application development](#quick-startup-for-application-development)
+* [Event subscription for state changes](#event-subscription-for-state-changes)
+* [Complex patterns for data flow](#complex-patterns-for-data-flow)
+* [Auditable open source](#auditable-open-source)
 
 You can also learn about [when Splinter might not be the right
-choice](#bookmark-why-not-splinter).
+choice](#why-not-splinter).
 
-## <a name="bookmark-private-circuits"></a> True Privacy with Circuits
+## True Privacy with Circuits
 
 Splinter was designed for privacy from the beginning, with a simple architecture
 that reduces operational complexity.
@@ -65,7 +65,7 @@ participants to be hidden from each other.
 * Splinter circuits **share state privately** &mdash; with circuit members only.
   No central database is required for storing data changes or state information.
 
-## <a name="bookmark-dl-service"></a> Distributed Ledger Platform as a Service
+## Distributed Ledger Platform as a Service
 
 Splinter uses services to provide distributed ledger functionality, including
 transaction processing, a consensus mechanism or other agreement protocol, and
@@ -137,7 +137,7 @@ nodes. Because Splinter doesn't embed a specific distributed ledger in its core
 architecture, adding a different style of distributed ledger is possible by
 replacing the Scabbard service with a different service or set of services.
 
-## <a name="bookmark-arch"></a> Flexibility with Splinter's Modular Architecture
+## Flexibility with Splinter's Modular Architecture
 
 Splinter supports both single and multiple processes for distributed ledger
 components. Other blockchain platforms have separate processes for the
@@ -162,7 +162,7 @@ communication mechanisms.
   layers, such as TCP or TLS, it can easily be extended to additional transport
   layers by implementing a few simple Rust traits.
 
-## <a name="bookmark-sm-share-state"></a> Smart Contracts That Can Share State
+## Smart Contracts That Can Share State
 
 [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre), which is
 included in the Scabbard service, implements **in-ledger smart contracts** that
@@ -188,7 +188,7 @@ Sawtooth transaction processor (Sawtooth's version of a smart contract) in Rust,
 then convert it to a Sabre smart contract that can be used for a Splinter
 circuit.
 
-## <a name="bookmark-dev-startup"></a> Quick Startup for Application Development
+## Quick Startup for Application Development
 
 Splinter includes several APIs for application development:
 
@@ -232,7 +232,7 @@ Splinter provides
 as a complete example for building smart-contract-based applications with the
 Splinter platform.
 
-## <a name="bookmark-event-sub"></a> Event Subscription for State Changes
+## Event Subscription for State Changes
 
 As described earlier, the Scabbard service includes Hyperledger Transact for
 transaction processing and state management. State agreement is achieved with
@@ -247,7 +247,7 @@ to another database, event stream, log, or other mechanism. This allows
 applications to query and analyze the smart contract state in their own
 business-specific databases.
 
-## <a name="bookmark-complex-data-flow"></a> Complex Patterns for Data Flow
+## Complex Patterns for Data Flow
 
 Splinter has clear benefits when compared to traditional EDI systems and ETL
 processes, which provide data- or outcome-focused data flows. Splinter enables
@@ -259,13 +259,13 @@ on changes (with verified state agreement), and export changes in the required
 format. Smart contracts allow even more elaborate patterns for data generation
 and updates.
 
-## <a name="bookmark-open-source"></a> Auditable Open Source
+## Auditable Open Source
 
 Splinter is open source software, licensed under the [Apache License Version
 2.0](https://github.com/Cargill/splinter/blob/master/LICENSE) software license.
 The Splinter source code is freely available and auditable.
 
-## <a name="bookmark-why-not-splinter"></a> Why NOT Splinter?
+## Why NOT Splinter?
 
 Even with all of its benefits, Splinter isn't perfect for all uses.
 For example:

--- a/docs/0.5/howto/planning_splinter_deployment.md
+++ b/docs/0.5/howto/planning_splinter_deployment.md
@@ -143,7 +143,7 @@ this pattern has been tested with the Splinter examples.
 
 ![](../images/splinter-deployment-kubernetes.png "Splinter Kubernetes deployment")
 
-# Amazon EKS Deployment
+## Amazon EKS Deployment
 
 This example of Amazon EKS deployment uses a classic load balancer (CLB) as the
 ingress and Amazon Elastic Block Storage (EBS) as the backing store for

--- a/docs/0.5/howto/planning_splinter_deployment.md
+++ b/docs/0.5/howto/planning_splinter_deployment.md
@@ -9,19 +9,19 @@ Kubernetes Services (Amazon EKS).
 
 **Contents**
 <br>
-[Overview](#bookmark=id.ls4meksnxna)
+[Overview](#overview)
 <br>
-[Splinter Architecture](#bookmark=id.qwe1rp9mdlx5)
+[Splinter Architecture](#splinter-architecture)
 <br>
-[Network Configuration](#bookmark=id.brrcajnirna1)
+[Network Configuration](#network-configuration)
 <br>
-[Application Pattern](#bookmark=id.w243im9kbun8)
+[Application Pattern](#application-pattern)
 <br>
-[Docker Deployment](#bookmark=id.i8nr28r242j4)
+[Docker Deployment](#docker-deployment)
 <br>
-[Basic Kubernetes Deployment](#bookmark=id.4gmpe3v077wl)
+[Basic Kubernetes Deployment](#basic-kubernetes-deployment)
 <br>
-[Amazon EKS Deployment](#bookmark=id.ism06ku1ut2h)
+[Amazon EKS Deployment](#amazon-eks-deployment)
 
 ## Overview
 

--- a/docs/0.5/index.md
+++ b/docs/0.5/index.md
@@ -18,19 +18,19 @@ application interfaces, and transaction processing.
 
 This topic describes Splinter's key benefits:
 
-* [True privacy with circuits](#bookmark-private-circuits)
-* [Distributed ledger platform as a service](#bookmark-dl-service)
-* [Flexibility with Splinter's modular architecture](#bookmark-arch)
-* [Smart contracts that can share state](#bookmark-sm-share-state)
-* [Quick startup for application development](#bookmark-dev-startup)
-* [Event subscription for state changes](#bookmark-event-sub)
-* [Complex patterns for data flow](#bookmark-complex-data-flow)
-* [Auditable open source](#bookmark-open-source)
+* [True privacy with circuits](#true-privacy-with-circuits)
+* [Distributed ledger platform as a service](#distributed-ledger-platform-as-a-service)
+* [Flexibility with Splinter's modular architecture](#flexibility-with-splinters-modular-architecture)
+* [Smart contracts that can share state](#smart-contracts-that-can-share-state)
+* [Quick startup for application development](#quick-startup-for-application-development)
+* [Event subscription for state changes](#event-subscription-for-state-changes)
+* [Complex patterns for data flow](#complex-patterns-for-data-flow)
+* [Auditable open source](#auditable-open-source)
 
 You can also learn about [when Splinter might not be the right
 choice](#bookmark-why-not-splinter).
 
-## <a name="bookmark-private-circuits"></a> True Privacy with Circuits
+## True Privacy with Circuits
 
 Splinter was designed for privacy from the beginning, with a simple architecture
 that reduces operational complexity.
@@ -65,7 +65,7 @@ participants to be hidden from each other.
 * Splinter circuits **share state privately** &mdash; with circuit members only.
   No central database is required for storing data changes or state information.
 
-## <a name="bookmark-dl-service"></a> Distributed Ledger Platform as a Service
+## Distributed Ledger Platform as a Service
 
 Splinter uses services to provide distributed ledger functionality, including
 transaction processing, a consensus mechanism or other agreement protocol, and
@@ -137,7 +137,7 @@ nodes. Because Splinter doesn't embed a specific distributed ledger in its core
 architecture, adding a different style of distributed ledger is possible by
 replacing the Scabbard service with a different service or set of services.
 
-## <a name="bookmark-arch"></a> Flexibility with Splinter's Modular Architecture
+## Flexibility with Splinter's Modular Architecture
 
 Splinter supports both single and multiple processes for distributed ledger
 components. Other blockchain platforms have separate processes for the
@@ -162,7 +162,7 @@ communication mechanisms.
   layers, such as TCP or TLS, it can easily be extended to additional transport
   layers by implementing a few simple Rust traits.
 
-## <a name="bookmark-sm-share-state"></a> Smart Contracts That Can Share State
+## Smart Contracts That Can Share State
 
 [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre), which is
 included in the Scabbard service, implements **in-ledger smart contracts** that
@@ -188,7 +188,7 @@ Sawtooth transaction processor (Sawtooth's version of a smart contract) in Rust,
 then convert it to a Sabre smart contract that can be used for a Splinter
 circuit.
 
-## <a name="bookmark-dev-startup"></a> Quick Startup for Application Development
+## Quick Startup for Application Development
 
 Splinter includes several APIs for application development:
 
@@ -232,7 +232,7 @@ Splinter provides
 as a complete example for building smart-contract-based applications with the
 Splinter platform.
 
-## <a name="bookmark-event-sub"></a> Event Subscription for State Changes
+## Event Subscription for State Changes
 
 As described earlier, the Scabbard service includes Hyperledger Transact for
 transaction processing and state management. State agreement is achieved with
@@ -247,7 +247,7 @@ to another database, event stream, log, or other mechanism. This allows
 applications to query and analyze the smart contract state in their own
 business-specific databases.
 
-## <a name="bookmark-complex-data-flow"></a> Complex Patterns for Data Flow
+## Complex Patterns for Data Flow
 
 Splinter has clear benefits when compared to traditional EDI systems and ETL
 processes, which provide data- or outcome-focused data flows. Splinter enables
@@ -259,13 +259,13 @@ on changes (with verified state agreement), and export changes in the required
 format. Smart contracts allow even more elaborate patterns for data generation
 and updates.
 
-## <a name="bookmark-open-source"></a> Auditable Open Source
+## Auditable Open Source
 
 Splinter is open source software, licensed under the [Apache License Version
 2.0](https://github.com/Cargill/splinter/blob/master/LICENSE) software license.
 The Splinter source code is freely available and auditable.
 
-## <a name="bookmark-why-not-splinter"></a> Why NOT Splinter?
+## Why NOT Splinter?
 
 Even with all of its benefits, Splinter isn't perfect for all uses.
 For example:

--- a/scripts/generateRightSidebar.js
+++ b/scripts/generateRightSidebar.js
@@ -15,21 +15,18 @@
 */
 
 function generateRightSidebar() {
-  var content = "";
-  var main = document.getElementById("main-content");
-  var i;
-  for (i = 0; i < main.children.length; i++) {
-    if (main.children[i].tagName.localeCompare("H2") == 0) {
-      content = content +
-        "<a href=#"+main.children[i].id +" class=\"right-sidebar-h2\">" +
-        main.children[i].innerText + "</a>";
-    }
-
-    if (main.children[i].tagName.localeCompare("H3") == 0) {
-      content = content +
-        "<a href=#"+main.children[i].id +" class=\"right-sidebar-h3\">" +
-        main.children[i].innerText + "</a>";
-    }
-  }
-  return content;
+  $("#main-content").children().each(function (idx, element) {
+      if ($(element).is("h2")) {
+          $("#right-sidebar").append(
+              "<a href=#" + element.id + " class=\"right-sidebar-h2\">" +
+              element.innerText + "</a>"
+          );
+      }
+      if ($(element).is("h3")) {
+          $("#right-sidebar").append(
+              "<a href=#" + element.id + " class=\"right-sidebar-h3\">" +
+              element.innerText + "</a>"
+          );
+      }
+  });
 }


### PR DESCRIPTION
Removes the explicitly defined anchor tags from the docs index markdown
files and uses the implicit markdown links instead. This fixes some
incorrect behavior with the website.

Signed-off-by: Logan Seeley <seeley@bitwise.io>