### PR TITLE
Change titles of About topics

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -22,8 +22,8 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
         <a href="/docs/0.4/glossary/glossary.html">Splinter glossary</a>
-        <a href="/docs/0.4/concepts/about_canopy.html">About Canopy</a>
-        <a href="/docs/0.4/concepts/about_biome.html">About Biome</a>
+        <a href="/docs/0.4/concepts/canopy_application_framework.html">Canopy application framework</a>
+        <a href="/docs/0.4/concepts/biome_user_management.html">Biome user management</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Example Applications</div>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -22,8 +22,8 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
         <a href="/docs/0.5/glossary/glossary.html">Splinter glossary</a>
-        <a href="/docs/0.5/concepts/about_canopy.html">About Canopy</a>
-        <a href="/docs/0.5/concepts/about_biome.html">About Biome</a>
+        <a href="/docs/0.5/concepts/canopy_application_framework.html">Canopy application framework</a>
+        <a href="/docs/0.5/concepts/biome_user_management.html">Biome user management</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Example Applications</div>

--- a/docs/0.4/concepts/biome_user_management.md
+++ b/docs/0.4/concepts/biome_user_management.md
@@ -1,4 +1,4 @@
-# About Biome
+# Biome User Management
 
 Biome is a module in libsplinter containing several submodules that provide
 support for user management, user credential management, and private key

--- a/docs/0.4/concepts/canopy_application_framework.md
+++ b/docs/0.4/concepts/canopy_application_framework.md
@@ -1,4 +1,4 @@
-# About Canopy
+# Canopy Application Framework
 
 Canopy is a JavaScript framework for building the client-side web portion of a
 full-stack [Splinter](https://github.com/Cargill/splinter) application. A

--- a/docs/0.4/examples/gameroom/walkthrough/index.md
+++ b/docs/0.4/examples/gameroom/walkthrough/index.md
@@ -25,7 +25,8 @@ Success. The browser now displays the ACME GAMEROOM HOME SCREEN.
 ### I-1. Behind scene 1: Alice logs into Acme's Gameroom UI
 
 Gameroom uses Biome for user management, including authentication. For more
-information on Biome, check out the Biome overview.
+information, check out the [Biome
+overview](../../../concepts/biome_user_management.md).
 
 When a user logs in, the user interface (UI) component of the Gameroom client
 application works with the Gameroom REST API to check the user's email address

--- a/docs/0.4/howto/planning_splinter_deployment.md
+++ b/docs/0.4/howto/planning_splinter_deployment.md
@@ -99,8 +99,8 @@ sends all HTTP requests to the TLS port.
 Users generally access the application with web-based apps that interact with
 Splinter through a web server and server-side application. Splinter includes
 **Canopy**, a distributed-application UI framework that dynamically loads
-distributed UI components called _Saplings_. See [About
-Canopy](https://github.com/Cargill/splinter-docs/blob/master/docs/concepts/about_canopy.md)
+distributed UI components called _Saplings_. See [Canopy Application
+Framework](../concepts/canopy_application_framework.md)
 for more information.
 
 The server-side application (application server) is commonly a single

--- a/docs/0.5/concepts/biome_user_management.md
+++ b/docs/0.5/concepts/biome_user_management.md
@@ -1,4 +1,4 @@
-# About Biome
+# Biome User Management
 
 Biome is a module in libsplinter containing several submodules that provide
 support for user management, user credential management, and private key

--- a/docs/0.5/concepts/canopy_application_framework.md
+++ b/docs/0.5/concepts/canopy_application_framework.md
@@ -1,4 +1,4 @@
-# About Canopy
+# Canopy Application Framework
 
 Canopy is a JavaScript framework for building the client-side web portion of a
 full-stack [Splinter](https://github.com/Cargill/splinter) application. A

--- a/docs/0.5/examples/gameroom/walkthrough/index.md
+++ b/docs/0.5/examples/gameroom/walkthrough/index.md
@@ -25,7 +25,8 @@ Success. The browser now displays the ACME GAMEROOM HOME SCREEN.
 ### I-1. Behind scene 1: Alice logs into Acme's Gameroom UI
 
 Gameroom uses Biome for user management, including authentication. For more
-information on Biome, check out the Biome overview.
+information, check out the [Biome
+overview](../../../concepts/biome_user_management.md).
 
 When a user logs in, the user interface (UI) component of the Gameroom client
 application works with the Gameroom REST API to check the user's email address

--- a/docs/0.5/howto/planning_splinter_deployment.md
+++ b/docs/0.5/howto/planning_splinter_deployment.md
@@ -99,8 +99,8 @@ sends all HTTP requests to the TLS port.
 Users generally access the application with web-based apps that interact with
 Splinter through a web server and server-side application. Splinter includes
 **Canopy**, a distributed-application UI framework that dynamically loads
-distributed UI components called _Saplings_. See [About
-Canopy](https://github.com/Cargill/splinter-docs/blob/master/docs/concepts/about_canopy.md)
+distributed UI components called _Saplings_. See [Canopy Application
+Framework](../concepts/canopy_application_framework.md)
 for more information.
 
 The server-side application (application server) is commonly a single

--- a/releases/0.4/index.md
+++ b/releases/0.4/index.md
@@ -105,8 +105,9 @@ information and provides the user keys that the rest of Splinter relies on.
 
 Splinter exposes several `/biome` REST API endpoints for registering users,
 accessing user information, updating passwords (or other access credentials) and
-more. See [About Biome](/docs/0.4/concepts/about_biome.html) and the `/biome`
-endpoints in the [splinterd REST API Reference](/docs/0.4/api/#tag/Biome).
+more. See [Biome User Management](/docs/0.4/concepts/biome_user_management.html)
+and the `/biome` endpoints in the [splinterd REST API
+Reference](/docs/0.4/api/#tag/Biome).
 
 ### Scabbard Service for Smart Contract Execution
 


### PR DESCRIPTION
Provide more specific (and helpful) topic titles:
- About Biome -> Biome User Management
- About Canopy -> Canopy Application Framework

Also update links (and add missing link) in other topics: 0.4 release overview, Gameroom walkthrough, and Planning a Splinter Deployment. These links now point to the published docs (not the markdown files in the repo) and use relative paths when possible.

Signed-off-by: Anne Chenette <chenette@bitwise.io>