### PR TITLE
Add "About Releases" page 

### DIFF
--- a/_includes/releases/left_sidebar.html
+++ b/_includes/releases/left_sidebar.html
@@ -20,4 +20,9 @@
         <a href="/releases/0.4/">Overview</a>
         <a href="/releases/0.4/upgrading/">Upgrading</a>
     </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Release Management</div>
+        <a href="/releases/management/versioning.html">Versioning</a>
+        <a href="/releases/management/artifacts.html">Artifacts</a>
+    </div>
 </div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -185,7 +185,7 @@ img {
 
 .left-sidebar-group .left-sidebar-header {
     font-weight: bold;
-    padding: 0 20px 5px 20px;
+    padding: 5px 20px;
 }
 
 .left-sidebar-group a {

--- a/releases/management/artifacts.md
+++ b/releases/management/artifacts.md
@@ -1,0 +1,36 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Published Artifacts
+
+The Splinter ecosystem includes a variety of published artifacts, including
+Docker images and Rust crates for the Splinter libraries. All Splinter artifacts
+are versioned together; this means that for each release, a new version of each
+artifact will be published with the new release number. This allows developers
+to easily select compatible versions of all crates and images.
+
+Below is a list of all major artifacts that are published with every Splinter
+release.
+
+## Rust crates
+
+* [splinter](https://crates.io/crates/splinter)
+* [scabbard](https://crates.io/crates/scabbard)
+
+## Docker images
+* [splintercommunity/splinterd](https://hub.docker.com/r/splintercommunity/splinterd)
+* [splintercommunity/splinter-cli](https://hub.docker.com/r/splintercommunity/splinter-cli)
+* [splintercommunity/scabbard-cli](https://hub.docker.com/r/splintercommunity/scabbard-cli)

--- a/releases/management/versioning.md
+++ b/releases/management/versioning.md
@@ -1,0 +1,31 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Release Versioning
+
+Splinter follows a pattern of alternating stable and development versions. Every
+even-numbered minor version (like 0.4) is a stable release, and every
+odd-numbered minor version (like 0.3 or 0.5) is a development release. The
+latest development release, when deemed complete by the team, will become the
+next stable release.
+
+The latest stable release should be the default choice for most use cases. Patch
+releases will be provided, but breaking changes will not be introduced in any
+patch releases.
+
+The latest development release may be used when cutting-edge features are
+desired, but should be used with caution. Patches will be released regularly,
+and breaking changes are likely to be introduced due to rapid development.


### PR DESCRIPTION
Adds the `/releases/about.html` page that explains Splinter's release
cycle and points to all of Splinter's major published artifacts.

Signed-off-by: Logan Seeley <seeley@bitwise.io>