### PR TITLE
Add "Features and Concepts" from Splinter README

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -36,6 +36,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
+        <a href="/docs/0.4/concepts/features_and_concepts.html">Features and Concepts</a>
         <a href="/docs/0.4/glossary/glossary.html">Splinter glossary</a>
         <a href="/docs/0.4/concepts/canopy_application_framework.html">Canopy application framework</a>
         <a href="/docs/0.4/concepts/biome_user_management.html">Biome user management</a>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -36,6 +36,7 @@
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
+        <a href="/docs/0.5/concepts/features_and_concepts.html">Features and Concepts</a>
         <a href="/docs/0.5/glossary/glossary.html">Splinter glossary</a>
         <a href="/docs/0.5/concepts/canopy_application_framework.html">Canopy application framework</a>
         <a href="/docs/0.5/concepts/biome_user_management.html">Biome user management</a>

--- a/docs/0.4/concepts/features_and_concepts.md
+++ b/docs/0.4/concepts/features_and_concepts.md
@@ -1,0 +1,83 @@
+# Features and Concepts
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+Splinter allows the same network to do two-party private communication,
+multi-party private communication, and network-wide multi-party shared state,
+all managed with consensus. A Splinter network enables multi-party or two-party
+private conversations between nodes using circuits and services.
+
+  - A _**node**_ is the foundational runtime that allows an organization to
+  participate in the network.
+
+  - A _**circuit**_ is a virtual network within the broader Splinter network
+  that safely and securely enforces prvacy scope boundaries.
+
+  - A _**service**_ is an endpoint within a circuit that sends and receives
+  private messages.
+
+A Splinter application provides a set of distributed services that can
+communicate with each other across a Splinter circuit.
+
+![Splinter private circuits with shared state](../images/diagram-splinter-circuits+3companies.svg)
+
+## Designed for privacy
+
+The key concepts of Splinter are fundamentally anchored to privacy.
+
+   - _**Circuits**_ define scope and visibility domains.
+
+   - _**Shared state**_, a database updated by smart contracts, is visible only
+     to the services within a circuit.
+
+## Distributed and flexible
+
+Splinter works across a network.
+
+   - _**State agreement**_ is achieved via the Merkle-radix tree in
+     [Hyperledger Transact](https://github.com/hyperledger/transact/),
+     allowing multiple services to prove they have the same data down to the
+     last bit, cryptographically.
+
+   - _**Consensus**_ is provided for creating real distributed applications.
+     Splinter currently includes **two-phase commit** for 2- or 3-party
+     conversations.
+
+   - _**Connections**_ are dynamically constructed between nodes as circuits are
+     created.
+
+
+![Splinter smart contract deployment at runtime](../images/diagram-splinter-smartcontractdeployment.svg)
+
+## Agile with smart contracts
+
+   - Smart contracts _**capture business logic**_ for processing transactions.
+
+   - _**Runtime deployment**_ of smart contracts means no need to upgrade the
+     Splinter software stack to add business logic.
+
+   - _**Sandboxed WebAssembly smart contracts**_ keep the network safe and
+     ensure determinism.
+
+   - _**Scabbard**_, an out-of-the-box Splinter service that runs
+     [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre)
+     smart contracts across nodes, coordinated with consensus.
+
+## Designed for applications
+
+   - _**State delta export**_ allows an application to materialize the
+     Merkle-radix tree database to another database such as PostgreSQL.
+     Applications can read from the materialized database (just like any other
+     web application).
+
+   - _**Admin services**_ provide applications with a REST API to dynamically
+     create new circuits, based on business need.
+
+   - _**Authorization**_ for circuit management can be delegated to application
+     code and defined by business policies.
+
+![Two-party Splinter circuit](../images/diagram-splinter-twopartycircuit.svg)

--- a/docs/0.4/images/diagram-splinter-circuits+3companies.svg
+++ b/docs/0.4/images/diagram-splinter-circuits+3companies.svg
@@ -1,0 +1,156 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="145.80913 -27.25 712.605 576.3836" width="712.605" height="576.3836">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-02 18:56:27 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_1" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 1</title>
+    <g id="Canvas_1: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_30">
+        <rect x="624.88" y="54.52432" width="226.28414" height="338.522" fill="#ebebeb"/>
+        <text transform="translate(629.88 59.52432)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="131.51615" y="15">Company B</tspan>
+        </text>
+      </g>
+      <g id="Graphic_29">
+        <rect x="313.2882" y="325.71222" width="296.92364" height="216.67137" fill="#ebebeb"/>
+        <text transform="translate(318.2882 518.9356)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="0" y="15">Company C</tspan>
+        </text>
+      </g>
+      <g id="Graphic_28">
+        <rect x="218.00142" y="36.6682" width="296.92364" height="231.97425" fill="#ebebeb"/>
+        <text transform="translate(223.00142 41.6682)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="0" y="15">Company A</tspan>
+        </text>
+      </g>
+      <g id="Graphic_27">
+        <path d="M 348.8632 158.71056 C 414.5352 213.97946 468.9928 328.35513 470.4976 414.1759 C 472.00277 499.9969 419.9853 524.76395 354.31325 469.4946 C 288.64122 414.2257 234.18367 299.85003 232.67884 214.02928 C 231.17368 128.20824 283.19116 103.44121 348.8632 158.71056" stroke="#00fa00" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_26">
+        <path d="M 757.7634 253.82992 C 668.4569 259.84647 552.7283 322.92634 499.2762 394.7228 C 445.8237 466.5193 474.88933 519.84416 564.19614 513.82725 C 653.5027 507.8107 769.2313 444.73083 822.6834 372.93436 C 876.1359 301.13786 847.0703 247.813 757.7634 253.82992" stroke="#0432ff" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_25">
+        <path d="M 397.2551 182.8844 C 470.29346 238.0447 602.4554 269.22677 692.4472 252.53152 C 782.4394 235.83655 796.1829 177.58646 723.14405 122.42624 C 650.1057 67.26594 517.94374 36.08388 427.9519 52.77913 C 337.9597 69.4741 324.2163 127.72419 397.2551 182.8844" stroke="#ff2600" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_24">
+        <rect x="264.8407" y="152.54368" width="66.03736" height="53.57989" fill="#c0ffc0"/>
+        <rect x="264.8407" y="152.54368" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_23">
+        <path d="M 278.41002 256.19306 L 278.41002 220.71947 C 278.41002 218.2718 285.50225 216.28527 294.2409 216.28527 C 302.97954 216.28527 310.07177 218.2718 310.07177 220.71947 L 310.07177 256.19306 C 310.07177 258.64073 302.97954 260.62725 294.2409 260.62725 C 285.50225 260.62725 278.41002 258.64073 278.41002 256.19306" fill="#c0ffc0"/>
+        <path d="M 278.41002 256.19306 L 278.41002 220.71947 C 278.41002 218.2718 285.50225 216.28527 294.2409 216.28527 C 302.97954 216.28527 310.07177 218.2718 310.07177 220.71947 L 310.07177 256.19306 C 310.07177 258.64073 302.97954 260.62725 294.2409 260.62725 C 285.50225 260.62725 278.41002 258.64073 278.41002 256.19306 M 278.41002 220.71947 C 278.41002 223.16715 285.50225 225.15367 294.2409 225.15367 C 302.97954 225.15367 310.07177 223.16715 310.07177 220.71947" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_22">
+        <rect x="374.2999" y="353.93017" width="66.03736" height="53.57989" fill="#c0ffc0"/>
+        <rect x="374.2999" y="353.93017" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_21">
+        <path d="M 408.6755 457.57955 L 408.6755 422.10597 C 408.6755 419.6583 415.76773 417.67177 424.50637 417.67177 C 433.245 417.67177 440.33725 419.6583 440.33725 422.10597 L 440.33725 457.57955 C 440.33725 460.02723 433.245 462.01375 424.50637 462.01375 C 415.76773 462.01375 408.6755 460.02723 408.6755 457.57955" fill="#c0ffc0"/>
+        <path d="M 408.6755 457.57955 L 408.6755 422.10597 C 408.6755 419.6583 415.76773 417.67177 424.50637 417.67177 C 433.245 417.67177 440.33725 419.6583 440.33725 422.10597 L 440.33725 457.57955 C 440.33725 460.02723 433.245 462.01375 424.50637 462.01375 C 415.76773 462.01375 408.6755 460.02723 408.6755 457.57955 M 408.6755 422.10597 C 408.6755 424.55364 415.76773 426.54016 424.50637 426.54016 C 433.245 426.54016 440.33725 424.55364 440.33725 422.10597" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_20">
+        <rect x="409.5801" y="80.48796" width="66.03736" height="53.57989" fill="#ffc0c0"/>
+        <rect x="409.5801" y="80.48796" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_19">
+        <path d="M 443.95573 184.13734 L 443.95573 148.66375 C 443.95573 146.21608 451.04796 144.22956 459.7866 144.22956 C 468.52525 144.22956 475.6175 146.21608 475.6175 148.66375 L 475.6175 184.13734 C 475.6175 186.58502 468.52525 188.57154 459.7866 188.57154 C 451.04796 188.57154 443.95573 186.58502 443.95573 184.13734" fill="#ffc0c0"/>
+        <path d="M 443.95573 184.13734 L 443.95573 148.66375 C 443.95573 146.21608 451.04796 144.22956 459.7866 144.22956 C 468.52525 144.22956 475.6175 146.21608 475.6175 148.66375 L 475.6175 184.13734 C 475.6175 186.58502 468.52525 188.57154 459.7866 188.57154 C 451.04796 188.57154 443.95573 186.58502 443.95573 184.13734 M 443.95573 148.66375 C 443.95573 151.11143 451.04796 153.09795 459.7866 153.09795 C 468.52525 153.09795 475.6175 151.11143 475.6175 148.66375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_18">
+        <rect x="639.35395" y="128.5251" width="66.03736" height="53.57989" fill="#ffc0c0"/>
+        <rect x="639.35395" y="128.5251" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_17">
+        <path d="M 673.72956 232.17448 L 673.72956 196.7009 C 673.72956 194.25322 680.8218 192.2667 689.5604 192.2667 C 698.2991 192.2667 705.3913 194.25322 705.3913 196.7009 L 705.3913 232.17448 C 705.3913 234.62216 698.2991 236.60868 689.5604 236.60868 C 680.8218 236.60868 673.72956 234.62216 673.72956 232.17448" fill="#ffc0c0"/>
+        <path d="M 673.72956 232.17448 L 673.72956 196.7009 C 673.72956 194.25322 680.8218 192.2667 689.5604 192.2667 C 698.2991 192.2667 705.3913 194.25322 705.3913 196.7009 L 705.3913 232.17448 C 705.3913 234.62216 698.2991 236.60868 689.5604 236.60868 C 680.8218 236.60868 673.72956 234.62216 673.72956 232.17448 M 673.72956 196.7009 C 673.72956 199.14858 680.8218 201.1351 689.5604 201.1351 C 698.2991 201.1351 705.3913 199.14858 705.3913 196.7009" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_16">
+        <rect x="698.1543" y="277.2555" width="66.03736" height="53.57989" fill="#bfc0ff"/>
+        <rect x="698.1543" y="277.2555" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_15">
+        <path d="M 732.52995 380.90488 L 732.52995 345.4313 C 732.52995 342.9836 739.6222 340.9971 748.3608 340.9971 C 757.0995 340.9971 764.1917 342.9836 764.1917 345.4313 L 764.1917 380.90488 C 764.1917 383.35255 757.0995 385.33907 748.3608 385.33907 C 739.6222 385.33907 732.52995 383.35255 732.52995 380.90488" fill="#c0c0ff"/>
+        <path d="M 732.52995 380.90488 L 732.52995 345.4313 C 732.52995 342.9836 739.6222 340.9971 748.3608 340.9971 C 757.0995 340.9971 764.1917 342.9836 764.1917 345.4313 L 764.1917 380.90488 C 764.1917 383.35255 757.0995 385.33907 748.3608 385.33907 C 739.6222 385.33907 732.52995 383.35255 732.52995 380.90488 M 732.52995 345.4313 C 732.52995 347.87897 739.6222 349.8655 748.3608 349.8655 C 757.0995 349.8655 764.1917 347.87897 764.1917 345.4313" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_14">
+        <rect x="527.1809" y="381.182" width="66.03736" height="53.57989" fill="#c0c0ff"/>
+        <rect x="527.1809" y="381.182" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_13">
+        <path d="M 561.5565 484.8314 L 561.5565 449.3578 C 561.5565 446.91013 568.64874 444.9236 577.3874 444.9236 C 586.126 444.9236 593.21826 446.91013 593.21826 449.3578 L 593.21826 484.8314 C 593.21826 487.27907 586.126 489.2656 577.3874 489.2656 C 568.64874 489.2656 561.5565 487.27907 561.5565 484.8314" fill="#c0c0ff"/>
+        <path d="M 561.5565 484.8314 L 561.5565 449.3578 C 561.5565 446.91013 568.64874 444.9236 577.3874 444.9236 C 586.126 444.9236 593.21826 446.91013 593.21826 449.3578 L 593.21826 484.8314 C 593.21826 487.27907 586.126 489.2656 577.3874 489.2656 C 568.64874 489.2656 561.5565 487.27907 561.5565 484.8314 M 561.5565 449.3578 C 561.5565 451.8055 568.64874 453.792 577.3874 453.792 C 586.126 453.792 593.21826 451.8055 593.21826 449.3578" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_12">
+        <path d="M 328.64622 -20 L 391.2067 -20 C 393.41583 -20 395.2067 -18.20914 395.2067 -16 L 395.2067 2.963459 C 395.2067 5.172598 393.41583 6.963459 391.2067 6.963459 L 328.64622 6.963459 C 326.4371 6.963459 324.64622 5.172598 324.64622 2.963459 L 324.64622 -16 C 324.64622 -18.20914 326.4371 -20 328.64622 -20 Z" fill="#ffffc0"/>
+        <path d="M 328.64622 -20 L 391.2067 -20 C 393.41583 -20 395.2067 -18.20914 395.2067 -16 L 395.2067 2.963459 C 395.2067 5.172598 393.41583 6.963459 391.2067 6.963459 L 328.64622 6.963459 C 326.4371 6.963459 324.64622 5.172598 324.64622 2.963459 L 324.64622 -16 C 324.64622 -18.20914 326.4371 -20 328.64622 -20 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(329.64622 -16.250326)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.2722334" y="16">Circuit</tspan>
+        </text>
+      </g>
+      <g id="Graphic_10">
+        <path d="M 747 506.8969 L 847.1641 506.8969 C 849.3733 506.8969 851.1641 508.68774 851.1641 510.8969 L 851.1641 529.86033 C 851.1641 532.0695 849.3733 533.86033 847.1641 533.86033 L 747 533.86033 C 744.7909 533.86033 743 532.0695 743 529.86033 L 743 510.8969 C 743 508.68774 744.7909 506.8969 747 506.8969 Z" fill="#ffffc0"/>
+        <path d="M 747 506.8969 L 847.1641 506.8969 C 849.3733 506.8969 851.1641 508.68774 851.1641 510.8969 L 851.1641 529.86033 C 851.1641 532.0695 849.3733 533.86033 847.1641 533.86033 L 747 533.86033 C 744.7909 533.86033 743 532.0695 743 529.86033 L 743 510.8969 C 743 508.68774 744.7909 506.8969 747 506.8969 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(748 510.64655)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="1.2180732" y="16">Shared State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_8">
+        <path d="M 163 303.87193 L 232.79744 303.87193 C 235.00658 303.87193 236.79744 305.6628 236.79744 307.87193 L 236.79744 326.8354 C 236.79744 329.04453 235.00658 330.8354 232.79744 330.8354 L 163 330.8354 C 160.79086 330.8354 159 329.04453 159 326.8354 L 159 307.87193 C 159 305.6628 160.79086 303.87193 163 303.87193 Z" fill="#ffffc0"/>
+        <path d="M 163 303.87193 L 232.79744 303.87193 C 235.00658 303.87193 236.79744 305.6628 236.79744 307.87193 L 236.79744 326.8354 C 236.79744 329.04453 235.00658 330.8354 232.79744 330.8354 L 163 330.8354 C 160.79086 330.8354 159 329.04453 159 326.8354 L 159 307.87193 C 159 305.6628 160.79086 303.87193 163 303.87193 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(164 307.6216)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.47472" y="16">Service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <path d="M 663.9592 -3.5770444 L 726.5197 -3.5770444 C 728.7288 -3.5770444 730.5197 -1.7861834 730.5197 .42295564 L 730.5197 19.386415 C 730.5197 21.595554 728.7288 23.386415 726.5197 23.386415 L 663.9592 23.386415 C 661.7501 23.386415 659.9592 21.595554 659.9592 19.386415 L 659.9592 .42295564 C 659.9592 -1.7861834 661.7501 -3.5770444 663.9592 -3.5770444 Z" fill="#ffffc0"/>
+        <path d="M 663.9592 -3.5770444 L 726.5197 -3.5770444 C 728.7288 -3.5770444 730.5197 -1.7861834 730.5197 .42295564 L 730.5197 19.386415 C 730.5197 21.595554 728.7288 23.386415 726.5197 23.386415 L 663.9592 23.386415 C 661.7501 23.386415 659.9592 21.595554 659.9592 19.386415 L 659.9592 .42295564 C 659.9592 -1.7861834 661.7501 -3.5770444 663.9592 -3.5770444 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(664.9592 .17262947)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="10.424233" y="16">Node</tspan>
+        </text>
+      </g>
+      <g id="Line_31">
+        <line x1="294.35816" y1="128.5251" x2="353.3806" y2="6.963459" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_32">
+        <line x1="431.771" y1="50.58253" x2="376.88925" y2="6.963459" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_33">
+        <line x1="514.92506" y1="38.57521" x2="659.9592" y2="15.514347" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_34">
+        <line x1="704.1647" y1="54.52432" x2="697.9362" y2="23.386415" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_35">
+        <line x1="278.45683" y1="206.12357" x2="207.66283" y2="303.87193" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_36">
+        <line x1="374.2999" y1="370.7293" x2="236.1982" y2="328.94235" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_37">
+        <line x1="755.1013" y1="384.91775" x2="792.9039" y2="506.8969" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_38">
+        <line x1="593.21826" y1="470.93417" x2="744.64765" y2="507.66134" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/0.4/images/diagram-splinter-smartcontractdeployment.svg
+++ b/docs/0.4/images/diagram-splinter-smartcontractdeployment.svg
@@ -1,0 +1,133 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="-204.29167 -122.25 778.953 358.0863" width="778.953" height="358.0863">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-9 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M -8 0 L 0 3 L 0 -3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-02 15:57:16 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_2" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 2</title>
+    <g id="Canvas_2: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_15">
+        <rect x="8.578" y="-45" width="205" height="233.375" fill="white"/>
+        <rect x="8.578" y="-45" width="205" height="233.375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(13.578 -40)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.748" y="33.448">(company A)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_14">
+        <rect x="-197.04167" y="79.375" width="114.622" height="105" fill="#c0ffff"/>
+        <rect x="-197.04167" y="79.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-192.04167 122.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_13">
+        <rect x="21.4765" y="92.25" width="179.1015" height="88.125" fill="#bfffc0"/>
+        <rect x="21.4765" y="92.25" width="179.1015" height="88.125" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(26.4765 97.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="49.72675" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_12">
+        <rect x="47.328" y="122.54167" width="127.5" height="46" fill="#c0ffff"/>
+        <rect x="47.328" y="122.54167" width="127.5" height="46" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(52.328 127.54167)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="37.262" y="15">Smart</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="23.638" y="33.448">Contracts</tspan>
+        </text>
+      </g>
+      <g id="Line_11">
+        <line x1="-82.41967" y1="132.8892" x2="11.57805" y2="134.55261" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_8">
+        <rect x="21.4765" y="14.875" width="179.203" height="65.343994" fill="#bfffc0"/>
+        <rect x="21.4765" y="14.875" width="179.203" height="65.343994" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(26.4765 19.875)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="34.0735" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="362.41133" y="-45" width="205" height="233.375" fill="white"/>
+        <rect x="362.41133" y="-45" width="205" height="233.375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(367.41133 -40)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.452" y="33.448">(company B)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_6">
+        <rect x="375.30983" y="92.25" width="179.1015" height="88.125" fill="#c0c0ff"/>
+        <rect x="375.30983" y="92.25" width="179.1015" height="88.125" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(380.30983 97.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="49.72675" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_5">
+        <rect x="401.16133" y="121.20833" width="127.5" height="46" fill="#c0ffff"/>
+        <rect x="401.16133" y="121.20833" width="127.5" height="46" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(406.16133 126.20833)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="37.262" y="15">Smart</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="23.638" y="33.448">Contracts</tspan>
+        </text>
+      </g>
+      <g id="Line_3">
+        <line x1="184.72793" y1="145.26414" x2="391.2614" y2="144.48586" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_17">
+        <rect x="375.30983" y="14.875" width="179.203" height="65.343994" fill="#c0c0ff"/>
+        <rect x="375.30983" y="14.875" width="179.203" height="65.343994" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(380.30983 19.875)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="34.0735" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_19">
+        <path d="M -193.04167 -115 L 36.333333 -115 C 38.542472 -115 40.333333 -113.20914 40.333333 -111 L 40.333333 -68.375 C 40.333333 -66.16586 38.542472 -64.375 36.333333 -64.375 L -193.04167 -64.375 C -195.2508 -64.375 -197.04167 -66.16586 -197.04167 -68.375 L -197.04167 -111 C -197.04167 -113.20914 -195.2508 -115 -193.04167 -115 Z" fill="#ffffc0"/>
+        <path d="M -193.04167 -115 L 36.333333 -115 C 38.542472 -115 40.333333 -113.20914 40.333333 -111 L 40.333333 -68.375 C 40.333333 -66.16586 38.542472 -64.375 36.333333 -64.375 L -193.04167 -64.375 C -195.2508 -64.375 -197.04167 -66.16586 -197.04167 -68.375 L -197.04167 -111 C -197.04167 -113.20914 -195.2508 -115 -193.04167 -115 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-192.04167 -109.15161)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="82.8715" y="16">Runtime</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="10.4155" y="35.46411">Smart Contract Deployment</tspan>
+        </text>
+      </g>
+      <g id="Line_18">
+        <line x1="-31.248125" y1="133.79475" x2="-73.01875" y2="-64.375" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_20">
+        <line x1="288.5944" y1="144.87274" x2="288.14098" y2="195.75" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Graphic_22">
+        <path d="M 222.24467 195.75 L 353.74467 195.75 C 355.9538 195.75 357.74467 197.54086 357.74467 199.75 L 357.74467 224.5863 C 357.74467 226.79544 355.9538 228.5863 353.74467 228.5863 L 222.24467 228.5863 C 220.03553 228.5863 218.24467 226.79544 218.24467 224.5863 L 218.24467 199.75 C 218.24467 197.54086 220.03553 195.75 222.24467 195.75 Z" fill="#ffffc0"/>
+        <path d="M 222.24467 195.75 L 353.74467 195.75 C 355.9538 195.75 357.74467 197.54086 357.74467 199.75 L 357.74467 224.5863 C 357.74467 226.79544 355.9538 228.5863 353.74467 228.5863 L 222.24467 228.5863 C 220.03553 228.5863 218.24467 226.79544 218.24467 224.5863 L 218.24467 199.75 C 218.24467 197.54086 220.03553 195.75 222.24467 195.75 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(223.24467 202.4361)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="5.47" y="16">Synchronization</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/0.4/images/diagram-splinter-twopartycircuit.svg
+++ b/docs/0.4/images/diagram-splinter-twopartycircuit.svg
@@ -1,0 +1,245 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="-597.8333 -115.66667 942.8333 397.62797" width="942.8333" height="397.62797">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-9 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M -8 0 L 0 3 L 0 -3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+    <font-face font-family="Helvetica Neue" font-size="13" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-01 23:12:27 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_3" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 3</title>
+    <g id="Canvas_3: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_28">
+        <rect x="-414.25" y="-63" width="205" height="263.75" fill="white"/>
+        <rect x="-414.25" y="-63" width="205" height="263.75" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-409.25 -58)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.748" y="33.448">(company A)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_27">
+        <rect x="-590.5833" y="30.375" width="114.622" height="105" fill="#c0ffc0"/>
+        <rect x="-590.5833" y="30.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-585.5833 73.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_26">
+        <rect x="-402.6875" y="102.75" width="181.875" height="90" fill="#c0ffc0"/>
+        <rect x="-402.6875" y="102.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-397.6875 107.75)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="51.1135" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_25">
+        <rect x="-402.6875" y="-.75" width="181.875" height="90" fill="#c0ffc0"/>
+        <rect x="-402.6875" y="-.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-397.6875 4.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="35.4095" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_23">
+        <rect x="-53.75" y="-63" width="205" height="263.75" fill="white"/>
+        <rect x="-53.75" y="-63" width="205" height="263.75" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-48.75 -58)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.452" y="33.448">(company B)</tspan>
+        </text>
+      </g>
+      <g id="Line_17">
+        <line x1="-466.06133" y1="82.875" x2="-437.65" y2="82.875" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_10">
+        <path d="M -578.2723 235.88333 L -578.2723 176.28333 C -578.2723 172.17093 -558.11233 168.83333 -533.27233 168.83333 C -508.43233 168.83333 -488.27233 172.17093 -488.27233 176.28333 L -488.27233 235.88333 C -488.27233 239.99573 -508.43233 243.33333 -533.27233 243.33333 C -558.11233 243.33333 -578.2723 239.99573 -578.2723 235.88333" fill="#c0ffc0"/>
+        <path d="M -578.2723 235.88333 L -578.2723 176.28333 C -578.2723 172.17093 -558.11233 168.83333 -533.27233 168.83333 C -508.43233 168.83333 -488.27233 172.17093 -488.27233 176.28333 L -488.27233 235.88333 C -488.27233 239.99573 -508.43233 243.33333 -533.27233 243.33333 C -558.11233 243.33333 -578.2723 239.99573 -578.2723 235.88333 M -578.2723 176.28333 C -578.2723 180.39573 -558.11233 183.73333 -533.27233 183.73333 C -508.43233 183.73333 -488.27233 180.39573 -488.27233 176.28333" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-573.2723 200.58433)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="5.92" y="15">Database</tspan>
+        </text>
+      </g>
+      <g id="Line_8">
+        <line x1="-338.427" y1="167.04314" x2="-478.56527" y2="195.12195" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_6">
+        <line x1="-533.27233" y1="135.375" x2="-533.27233" y2="158.93333" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_2">
+        <path d="M -338.427 180.4564 L -338.427 142.9396 C -338.427 140.35094 -326.4757 138.25 -311.75 138.25 C -297.0243 138.25 -285.073 140.35094 -285.073 142.9396 L -285.073 180.4564 C -285.073 183.04506 -297.0243 185.146 -311.75 185.146 C -326.4757 185.146 -338.427 183.04506 -338.427 180.4564" fill="#deffd6"/>
+        <path d="M -338.427 180.4564 L -338.427 142.9396 C -338.427 140.35094 -326.4757 138.25 -311.75 138.25 C -297.0243 138.25 -285.073 140.35094 -285.073 142.9396 L -285.073 180.4564 C -285.073 183.04506 -297.0243 185.146 -311.75 185.146 C -326.4757 185.146 -338.427 183.04506 -338.427 180.4564 M -338.427 142.9396 C -338.427 145.52826 -326.4757 147.6292 -311.75 147.6292 C -297.0243 147.6292 -285.073 145.52826 -285.073 142.9396" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-333.427 152.6292)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="2.861" y="15">State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_29">
+        <path d="M -212.4375 241.875 L -50.5625 241.875 C -48.35336 241.875 -46.5625 243.66586 -46.5625 245.875 L -46.5625 270.7113 C -46.5625 272.92044 -48.35336 274.7113 -50.5625 274.7113 L -212.4375 274.7113 C -214.64664 274.7113 -216.4375 272.92044 -216.4375 270.7113 L -216.4375 245.875 C -216.4375 243.66586 -214.64664 241.875 -212.4375 241.875 Z" fill="#ffffc0"/>
+        <path d="M -212.4375 241.875 L -50.5625 241.875 C -48.35336 241.875 -46.5625 243.66586 -46.5625 245.875 L -46.5625 270.7113 C -46.5625 272.92044 -48.35336 274.7113 -50.5625 274.7113 L -212.4375 274.7113 C -214.64664 274.7113 -216.4375 272.92044 -216.4375 270.7113 L -216.4375 245.875 C -216.4375 243.66586 -214.64664 241.875 -212.4375 241.875 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-211.4375 248.5611)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="12.3695" y="16">State Delta Export</tspan>
+        </text>
+      </g>
+      <g id="Graphic_30">
+        <path d="M -184.811 102.5387 L -78.189 102.5387 C -75.97986 102.5387 -74.189 104.32956 -74.189 106.5387 L -74.189 131.375 C -74.189 133.58414 -75.97986 135.375 -78.189 135.375 L -184.811 135.375 C -187.02014 135.375 -188.811 133.58414 -188.811 131.375 L -188.811 106.5387 C -188.811 104.32956 -187.02014 102.5387 -184.811 102.5387 Z" fill="#ffffc0"/>
+        <path d="M -184.811 102.5387 L -78.189 102.5387 C -75.97986 102.5387 -74.189 104.32956 -74.189 106.5387 L -74.189 131.375 C -74.189 133.58414 -75.97986 135.375 -78.189 135.375 L -184.811 135.375 C -187.02014 135.375 -188.811 133.58414 -188.811 131.375 L -188.811 106.5387 C -188.811 104.32956 -187.02014 102.5387 -184.811 102.5387 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-183.811 109.22479)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="4.447001" y="16">Shared State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_31">
+        <path d="M -583.247 -108.41667 L -386.247 -108.41667 C -384.03786 -108.41667 -382.247 -106.6258 -382.247 -104.41667 L -382.247 -79.58036 C -382.247 -77.37122 -384.03786 -75.58036 -386.247 -75.58036 L -583.247 -75.58036 C -585.45614 -75.58036 -587.247 -77.37122 -587.247 -79.58036 L -587.247 -104.41667 C -587.247 -106.6258 -585.45614 -108.41667 -583.247 -108.41667 Z" fill="#ffffc0"/>
+        <path d="M -583.247 -108.41667 L -386.247 -108.41667 C -384.03786 -108.41667 -382.247 -106.6258 -382.247 -104.41667 L -382.247 -79.58036 C -382.247 -77.37122 -384.03786 -75.58036 -386.247 -75.58036 L -583.247 -75.58036 C -585.45614 -75.58036 -587.247 -77.37122 -587.247 -79.58036 L -587.247 -104.41667 C -587.247 -106.6258 -585.45614 -108.41667 -583.247 -108.41667 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-582.247 -101.73057)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="5.468" y="16">Dynamic Circuit Creation</tspan>
+        </text>
+      </g>
+      <g id="Graphic_32">
+        <path d="M -184.811 -21.93469 L -78.189 -21.93469 C -75.97986 -21.93469 -74.189 -20.14383 -74.189 -17.934691 L -74.189 20.961305 C -74.189 23.170444 -75.97986 24.961305 -78.189 24.961305 L -184.811 24.961305 C -187.02014 24.961305 -188.811 23.170444 -188.811 20.961305 L -188.811 -17.934691 C -188.811 -20.14383 -187.02014 -21.93469 -184.811 -21.93469 Z" fill="#ffffc0"/>
+        <path d="M -184.811 -21.93469 L -78.189 -21.93469 C -75.97986 -21.93469 -74.189 -20.14383 -74.189 -17.934691 L -74.189 20.961305 C -74.189 23.170444 -75.97986 24.961305 -78.189 24.961305 L -184.811 24.961305 C -187.02014 24.961305 -188.811 23.170444 -188.811 20.961305 L -188.811 -17.934691 C -188.811 -20.14383 -187.02014 -21.93469 -184.811 -21.93469 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-183.811 -17.950804)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="11.111001" y="16">Consensus</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="4.591001" y="35.46411">Coordination</tspan>
+        </text>
+      </g>
+      <g id="Graphic_34">
+        <path d="M 136.75 -108.41667 L 333.75 -108.41667 C 335.95914 -108.41667 337.75 -106.6258 337.75 -104.41667 L 337.75 -79.58036 C 337.75 -77.37122 335.95914 -75.58036 333.75 -75.58036 L 136.75 -75.58036 C 134.54086 -75.58036 132.75 -77.37122 132.75 -79.58036 L 132.75 -104.41667 C 132.75 -106.6258 134.54086 -108.41667 136.75 -108.41667 Z" fill="#ffffc0"/>
+        <path d="M 136.75 -108.41667 L 333.75 -108.41667 C 335.95914 -108.41667 337.75 -106.6258 337.75 -104.41667 L 337.75 -79.58036 C 337.75 -77.37122 335.95914 -75.58036 333.75 -75.58036 L 136.75 -75.58036 C 134.54086 -75.58036 132.75 -77.37122 132.75 -79.58036 L 132.75 -104.41667 C 132.75 -106.6258 134.54086 -108.41667 136.75 -108.41667 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(137.75 -101.73057)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.508" y="16">Authorization Delegation</tspan>
+        </text>
+      </g>
+      <g id="Graphic_42">
+        <rect x="-42.1875" y="102.75" width="181.875" height="90" fill="#c0c0ff"/>
+        <rect x="-42.1875" y="102.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-37.1875 107.75)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="51.1135" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_41">
+        <rect x="-42.1875" y="-.75" width="181.875" height="90" fill="#c0c0ff"/>
+        <rect x="-42.1875" y="-.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-37.1875 4.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="35.4095" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_40">
+        <rect x="-3.372" y="38.46867" width="104.244" height="28.447998" fill="#dde1ff"/>
+        <rect x="-3.372" y="38.46867" width="104.244" height="28.447998" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1.628 43.46867)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.114002" y="15">Consensus</tspan>
+        </text>
+      </g>
+      <g id="Graphic_38">
+        <rect x="120.375" y="30.375" width="45.503" height="105" fill="#dde1ff"/>
+        <rect x="120.375" y="30.375" width="45.503" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(125.375 67.511)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="1.3844992" y="12">REST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="7.643999" y="27.364">API</tspan>
+        </text>
+      </g>
+      <g id="Graphic_43">
+        <rect x="-427.75" y="30.375" width="45.503" height="105" fill="#deffd6"/>
+        <rect x="-427.75" y="30.375" width="45.503" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-422.75 67.511)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="1.3844992" y="12">REST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="7.643999" y="27.364">API</tspan>
+        </text>
+      </g>
+      <g id="Graphic_44">
+        <rect x="-363.872" y="40.583333" width="104.244" height="28.447998" fill="#deffd6"/>
+        <rect x="-363.872" y="40.583333" width="104.244" height="28.447998" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-358.872 45.583333)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.114002" y="15">Consensus</tspan>
+        </text>
+      </g>
+      <g id="Line_36">
+        <line x1="-249.72817" y1="54.44352" x2="-13.27183" y2="53.05648" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_51">
+        <rect x="215.91667" y="30.375" width="114.622" height="105" fill="#c0c0ff"/>
+        <rect x="215.91667" y="30.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(220.91667 73.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Line_50">
+        <line x1="206.01667" y1="82.875" x2="175.778" y2="82.875" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_52">
+        <line x1="-275.173" y1="161.698" x2="12.173" y2="161.698" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_39">
+        <path d="M 22.073 180.4564 L 22.073 142.9396 C 22.073 140.35094 34.024296 138.25 48.75 138.25 C 63.475704 138.25 75.427 140.35094 75.427 142.9396 L 75.427 180.4564 C 75.427 183.04506 63.475704 185.146 48.75 185.146 C 34.024296 185.146 22.073 183.04506 22.073 180.4564" fill="#dde1ff"/>
+        <path d="M 22.073 180.4564 L 22.073 142.9396 C 22.073 140.35094 34.024296 138.25 48.75 138.25 C 63.475704 138.25 75.427 140.35094 75.427 142.9396 L 75.427 180.4564 C 75.427 183.04506 63.475704 185.146 48.75 185.146 C 34.024296 185.146 22.073 183.04506 22.073 180.4564 M 22.073 142.9396 C 22.073 145.52826 34.024296 147.6292 48.75 147.6292 C 63.475704 147.6292 75.427 145.52826 75.427 142.9396" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(27.073 152.6292)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="2.861" y="15">State</tspan>
+        </text>
+      </g>
+      <g id="Line_53">
+        <line x1="189.33333" y1="82.875" x2="230.93907" y2="-75.58036" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_54">
+        <line x1="-453.1113" y1="82.875" x2="-481.77685" y2="-75.58036" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_55">
+        <line x1="-132.00145" y1="53.75294" x2="-131.72508" y2="24.961305" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_56">
+        <line x1="-131.69206" y1="135.375" x2="-132" y2="161.698" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_58">
+        <line x1="-215.37287" y1="243.1577" x2="-479.98534" y2="195.40648" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Graphic_60">
+        <rect x="216.16667" y="30.625" width="114.622" height="105" fill="#c0c0ff"/>
+        <rect x="216.16667" y="30.625" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(221.16667 73.901)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_59">
+        <path d="M 228.47767 236.13333 L 228.47767 176.53333 C 228.47767 172.42093 248.63767 169.08333 273.47767 169.08333 C 298.31767 169.08333 318.47767 172.42093 318.47767 176.53333 L 318.47767 236.13333 C 318.47767 240.24573 298.31767 243.58333 273.47767 243.58333 C 248.63767 243.58333 228.47767 240.24573 228.47767 236.13333" fill="#c0c0ff"/>
+        <path d="M 228.47767 236.13333 L 228.47767 176.53333 C 228.47767 172.42093 248.63767 169.08333 273.47767 169.08333 C 298.31767 169.08333 318.47767 172.42093 318.47767 176.53333 L 318.47767 236.13333 C 318.47767 240.24573 298.31767 243.58333 273.47767 243.58333 C 248.63767 243.58333 228.47767 240.24573 228.47767 236.13333 M 228.47767 176.53333 C 228.47767 180.64573 248.63767 183.98333 273.47767 183.98333 C 298.31767 183.98333 318.47767 180.64573 318.47767 176.53333" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(233.47767 200.83433)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="5.92" y="15">Database</tspan>
+        </text>
+      </g>
+      <g id="Line_61">
+        <line x1="273.47767" y1="135.625" x2="273.47767" y2="159.18333" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_62">
+        <line x1="-47.39789" y1="243.4282" x2="221.21045" y2="195.95204" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_63">
+        <line x1="75.427" y1="166.99658" x2="218.76735" y2="195.46679" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/0.5/concepts/features_and_concepts.md
+++ b/docs/0.5/concepts/features_and_concepts.md
@@ -1,0 +1,83 @@
+# Features and Concepts
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+Splinter allows the same network to do two-party private communication,
+multi-party private communication, and network-wide multi-party shared state,
+all managed with consensus. A Splinter network enables multi-party or two-party
+private conversations between nodes using circuits and services.
+
+  - A _**node**_ is the foundational runtime that allows an organization to
+  participate in the network.
+
+  - A _**circuit**_ is a virtual network within the broader Splinter network
+  that safely and securely enforces prvacy scope boundaries.
+
+  - A _**service**_ is an endpoint within a circuit that sends and receives
+  private messages.
+
+A Splinter application provides a set of distributed services that can
+communicate with each other across a Splinter circuit.
+
+![Splinter private circuits with shared state](../images/diagram-splinter-circuits+3companies.svg)
+
+## Designed for privacy
+
+The key concepts of Splinter are fundamentally anchored to privacy.
+
+   - _**Circuits**_ define scope and visibility domains.
+
+   - _**Shared state**_, a database updated by smart contracts, is visible only
+     to the services within a circuit.
+
+## Distributed and flexible
+
+Splinter works across a network.
+
+   - _**State agreement**_ is achieved via the Merkle-radix tree in
+     [Hyperledger Transact](https://github.com/hyperledger/transact/),
+     allowing multiple services to prove they have the same data down to the
+     last bit, cryptographically.
+
+   - _**Consensus**_ is provided for creating real distributed applications.
+     Splinter currently includes **two-phase commit** for 2- or 3-party
+     conversations.
+
+   - _**Connections**_ are dynamically constructed between nodes as circuits are
+     created.
+
+
+![Splinter smart contract deployment at runtime](../images/diagram-splinter-smartcontractdeployment.svg)
+
+## Agile with smart contracts
+
+   - Smart contracts _**capture business logic**_ for processing transactions.
+
+   - _**Runtime deployment**_ of smart contracts means no need to upgrade the
+     Splinter software stack to add business logic.
+
+   - _**Sandboxed WebAssembly smart contracts**_ keep the network safe and
+     ensure determinism.
+
+   - _**Scabbard**_, an out-of-the-box Splinter service that runs
+     [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre)
+     smart contracts across nodes, coordinated with consensus.
+
+## Designed for applications
+
+   - _**State delta export**_ allows an application to materialize the
+     Merkle-radix tree database to another database such as PostgreSQL.
+     Applications can read from the materialized database (just like any other
+     web application).
+
+   - _**Admin services**_ provide applications with a REST API to dynamically
+     create new circuits, based on business need.
+
+   - _**Authorization**_ for circuit management can be delegated to application
+     code and defined by business policies.
+
+![Two-party Splinter circuit](../images/diagram-splinter-twopartycircuit.svg)

--- a/docs/0.5/images/diagram-splinter-circuits+3companies.svg
+++ b/docs/0.5/images/diagram-splinter-circuits+3companies.svg
@@ -1,0 +1,156 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="145.80913 -27.25 712.605 576.3836" width="712.605" height="576.3836">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-02 18:56:27 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_1" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 1</title>
+    <g id="Canvas_1: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_30">
+        <rect x="624.88" y="54.52432" width="226.28414" height="338.522" fill="#ebebeb"/>
+        <text transform="translate(629.88 59.52432)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="131.51615" y="15">Company B</tspan>
+        </text>
+      </g>
+      <g id="Graphic_29">
+        <rect x="313.2882" y="325.71222" width="296.92364" height="216.67137" fill="#ebebeb"/>
+        <text transform="translate(318.2882 518.9356)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="0" y="15">Company C</tspan>
+        </text>
+      </g>
+      <g id="Graphic_28">
+        <rect x="218.00142" y="36.6682" width="296.92364" height="231.97425" fill="#ebebeb"/>
+        <text transform="translate(223.00142 41.6682)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="0" y="15">Company A</tspan>
+        </text>
+      </g>
+      <g id="Graphic_27">
+        <path d="M 348.8632 158.71056 C 414.5352 213.97946 468.9928 328.35513 470.4976 414.1759 C 472.00277 499.9969 419.9853 524.76395 354.31325 469.4946 C 288.64122 414.2257 234.18367 299.85003 232.67884 214.02928 C 231.17368 128.20824 283.19116 103.44121 348.8632 158.71056" stroke="#00fa00" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_26">
+        <path d="M 757.7634 253.82992 C 668.4569 259.84647 552.7283 322.92634 499.2762 394.7228 C 445.8237 466.5193 474.88933 519.84416 564.19614 513.82725 C 653.5027 507.8107 769.2313 444.73083 822.6834 372.93436 C 876.1359 301.13786 847.0703 247.813 757.7634 253.82992" stroke="#0432ff" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_25">
+        <path d="M 397.2551 182.8844 C 470.29346 238.0447 602.4554 269.22677 692.4472 252.53152 C 782.4394 235.83655 796.1829 177.58646 723.14405 122.42624 C 650.1057 67.26594 517.94374 36.08388 427.9519 52.77913 C 337.9597 69.4741 324.2163 127.72419 397.2551 182.8844" stroke="#ff2600" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3.0,12.0" stroke-width="3"/>
+      </g>
+      <g id="Graphic_24">
+        <rect x="264.8407" y="152.54368" width="66.03736" height="53.57989" fill="#c0ffc0"/>
+        <rect x="264.8407" y="152.54368" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_23">
+        <path d="M 278.41002 256.19306 L 278.41002 220.71947 C 278.41002 218.2718 285.50225 216.28527 294.2409 216.28527 C 302.97954 216.28527 310.07177 218.2718 310.07177 220.71947 L 310.07177 256.19306 C 310.07177 258.64073 302.97954 260.62725 294.2409 260.62725 C 285.50225 260.62725 278.41002 258.64073 278.41002 256.19306" fill="#c0ffc0"/>
+        <path d="M 278.41002 256.19306 L 278.41002 220.71947 C 278.41002 218.2718 285.50225 216.28527 294.2409 216.28527 C 302.97954 216.28527 310.07177 218.2718 310.07177 220.71947 L 310.07177 256.19306 C 310.07177 258.64073 302.97954 260.62725 294.2409 260.62725 C 285.50225 260.62725 278.41002 258.64073 278.41002 256.19306 M 278.41002 220.71947 C 278.41002 223.16715 285.50225 225.15367 294.2409 225.15367 C 302.97954 225.15367 310.07177 223.16715 310.07177 220.71947" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_22">
+        <rect x="374.2999" y="353.93017" width="66.03736" height="53.57989" fill="#c0ffc0"/>
+        <rect x="374.2999" y="353.93017" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_21">
+        <path d="M 408.6755 457.57955 L 408.6755 422.10597 C 408.6755 419.6583 415.76773 417.67177 424.50637 417.67177 C 433.245 417.67177 440.33725 419.6583 440.33725 422.10597 L 440.33725 457.57955 C 440.33725 460.02723 433.245 462.01375 424.50637 462.01375 C 415.76773 462.01375 408.6755 460.02723 408.6755 457.57955" fill="#c0ffc0"/>
+        <path d="M 408.6755 457.57955 L 408.6755 422.10597 C 408.6755 419.6583 415.76773 417.67177 424.50637 417.67177 C 433.245 417.67177 440.33725 419.6583 440.33725 422.10597 L 440.33725 457.57955 C 440.33725 460.02723 433.245 462.01375 424.50637 462.01375 C 415.76773 462.01375 408.6755 460.02723 408.6755 457.57955 M 408.6755 422.10597 C 408.6755 424.55364 415.76773 426.54016 424.50637 426.54016 C 433.245 426.54016 440.33725 424.55364 440.33725 422.10597" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_20">
+        <rect x="409.5801" y="80.48796" width="66.03736" height="53.57989" fill="#ffc0c0"/>
+        <rect x="409.5801" y="80.48796" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_19">
+        <path d="M 443.95573 184.13734 L 443.95573 148.66375 C 443.95573 146.21608 451.04796 144.22956 459.7866 144.22956 C 468.52525 144.22956 475.6175 146.21608 475.6175 148.66375 L 475.6175 184.13734 C 475.6175 186.58502 468.52525 188.57154 459.7866 188.57154 C 451.04796 188.57154 443.95573 186.58502 443.95573 184.13734" fill="#ffc0c0"/>
+        <path d="M 443.95573 184.13734 L 443.95573 148.66375 C 443.95573 146.21608 451.04796 144.22956 459.7866 144.22956 C 468.52525 144.22956 475.6175 146.21608 475.6175 148.66375 L 475.6175 184.13734 C 475.6175 186.58502 468.52525 188.57154 459.7866 188.57154 C 451.04796 188.57154 443.95573 186.58502 443.95573 184.13734 M 443.95573 148.66375 C 443.95573 151.11143 451.04796 153.09795 459.7866 153.09795 C 468.52525 153.09795 475.6175 151.11143 475.6175 148.66375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_18">
+        <rect x="639.35395" y="128.5251" width="66.03736" height="53.57989" fill="#ffc0c0"/>
+        <rect x="639.35395" y="128.5251" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_17">
+        <path d="M 673.72956 232.17448 L 673.72956 196.7009 C 673.72956 194.25322 680.8218 192.2667 689.5604 192.2667 C 698.2991 192.2667 705.3913 194.25322 705.3913 196.7009 L 705.3913 232.17448 C 705.3913 234.62216 698.2991 236.60868 689.5604 236.60868 C 680.8218 236.60868 673.72956 234.62216 673.72956 232.17448" fill="#ffc0c0"/>
+        <path d="M 673.72956 232.17448 L 673.72956 196.7009 C 673.72956 194.25322 680.8218 192.2667 689.5604 192.2667 C 698.2991 192.2667 705.3913 194.25322 705.3913 196.7009 L 705.3913 232.17448 C 705.3913 234.62216 698.2991 236.60868 689.5604 236.60868 C 680.8218 236.60868 673.72956 234.62216 673.72956 232.17448 M 673.72956 196.7009 C 673.72956 199.14858 680.8218 201.1351 689.5604 201.1351 C 698.2991 201.1351 705.3913 199.14858 705.3913 196.7009" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_16">
+        <rect x="698.1543" y="277.2555" width="66.03736" height="53.57989" fill="#bfc0ff"/>
+        <rect x="698.1543" y="277.2555" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_15">
+        <path d="M 732.52995 380.90488 L 732.52995 345.4313 C 732.52995 342.9836 739.6222 340.9971 748.3608 340.9971 C 757.0995 340.9971 764.1917 342.9836 764.1917 345.4313 L 764.1917 380.90488 C 764.1917 383.35255 757.0995 385.33907 748.3608 385.33907 C 739.6222 385.33907 732.52995 383.35255 732.52995 380.90488" fill="#c0c0ff"/>
+        <path d="M 732.52995 380.90488 L 732.52995 345.4313 C 732.52995 342.9836 739.6222 340.9971 748.3608 340.9971 C 757.0995 340.9971 764.1917 342.9836 764.1917 345.4313 L 764.1917 380.90488 C 764.1917 383.35255 757.0995 385.33907 748.3608 385.33907 C 739.6222 385.33907 732.52995 383.35255 732.52995 380.90488 M 732.52995 345.4313 C 732.52995 347.87897 739.6222 349.8655 748.3608 349.8655 C 757.0995 349.8655 764.1917 347.87897 764.1917 345.4313" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_14">
+        <rect x="527.1809" y="381.182" width="66.03736" height="53.57989" fill="#c0c0ff"/>
+        <rect x="527.1809" y="381.182" width="66.03736" height="53.57989" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_13">
+        <path d="M 561.5565 484.8314 L 561.5565 449.3578 C 561.5565 446.91013 568.64874 444.9236 577.3874 444.9236 C 586.126 444.9236 593.21826 446.91013 593.21826 449.3578 L 593.21826 484.8314 C 593.21826 487.27907 586.126 489.2656 577.3874 489.2656 C 568.64874 489.2656 561.5565 487.27907 561.5565 484.8314" fill="#c0c0ff"/>
+        <path d="M 561.5565 484.8314 L 561.5565 449.3578 C 561.5565 446.91013 568.64874 444.9236 577.3874 444.9236 C 586.126 444.9236 593.21826 446.91013 593.21826 449.3578 L 593.21826 484.8314 C 593.21826 487.27907 586.126 489.2656 577.3874 489.2656 C 568.64874 489.2656 561.5565 487.27907 561.5565 484.8314 M 561.5565 449.3578 C 561.5565 451.8055 568.64874 453.792 577.3874 453.792 C 586.126 453.792 593.21826 451.8055 593.21826 449.3578" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_12">
+        <path d="M 328.64622 -20 L 391.2067 -20 C 393.41583 -20 395.2067 -18.20914 395.2067 -16 L 395.2067 2.963459 C 395.2067 5.172598 393.41583 6.963459 391.2067 6.963459 L 328.64622 6.963459 C 326.4371 6.963459 324.64622 5.172598 324.64622 2.963459 L 324.64622 -16 C 324.64622 -18.20914 326.4371 -20 328.64622 -20 Z" fill="#ffffc0"/>
+        <path d="M 328.64622 -20 L 391.2067 -20 C 393.41583 -20 395.2067 -18.20914 395.2067 -16 L 395.2067 2.963459 C 395.2067 5.172598 393.41583 6.963459 391.2067 6.963459 L 328.64622 6.963459 C 326.4371 6.963459 324.64622 5.172598 324.64622 2.963459 L 324.64622 -16 C 324.64622 -18.20914 326.4371 -20 328.64622 -20 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(329.64622 -16.250326)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.2722334" y="16">Circuit</tspan>
+        </text>
+      </g>
+      <g id="Graphic_10">
+        <path d="M 747 506.8969 L 847.1641 506.8969 C 849.3733 506.8969 851.1641 508.68774 851.1641 510.8969 L 851.1641 529.86033 C 851.1641 532.0695 849.3733 533.86033 847.1641 533.86033 L 747 533.86033 C 744.7909 533.86033 743 532.0695 743 529.86033 L 743 510.8969 C 743 508.68774 744.7909 506.8969 747 506.8969 Z" fill="#ffffc0"/>
+        <path d="M 747 506.8969 L 847.1641 506.8969 C 849.3733 506.8969 851.1641 508.68774 851.1641 510.8969 L 851.1641 529.86033 C 851.1641 532.0695 849.3733 533.86033 847.1641 533.86033 L 747 533.86033 C 744.7909 533.86033 743 532.0695 743 529.86033 L 743 510.8969 C 743 508.68774 744.7909 506.8969 747 506.8969 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(748 510.64655)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="1.2180732" y="16">Shared State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_8">
+        <path d="M 163 303.87193 L 232.79744 303.87193 C 235.00658 303.87193 236.79744 305.6628 236.79744 307.87193 L 236.79744 326.8354 C 236.79744 329.04453 235.00658 330.8354 232.79744 330.8354 L 163 330.8354 C 160.79086 330.8354 159 329.04453 159 326.8354 L 159 307.87193 C 159 305.6628 160.79086 303.87193 163 303.87193 Z" fill="#ffffc0"/>
+        <path d="M 163 303.87193 L 232.79744 303.87193 C 235.00658 303.87193 236.79744 305.6628 236.79744 307.87193 L 236.79744 326.8354 C 236.79744 329.04453 235.00658 330.8354 232.79744 330.8354 L 163 330.8354 C 160.79086 330.8354 159 329.04453 159 326.8354 L 159 307.87193 C 159 305.6628 160.79086 303.87193 163 303.87193 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(164 307.6216)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.47472" y="16">Service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <path d="M 663.9592 -3.5770444 L 726.5197 -3.5770444 C 728.7288 -3.5770444 730.5197 -1.7861834 730.5197 .42295564 L 730.5197 19.386415 C 730.5197 21.595554 728.7288 23.386415 726.5197 23.386415 L 663.9592 23.386415 C 661.7501 23.386415 659.9592 21.595554 659.9592 19.386415 L 659.9592 .42295564 C 659.9592 -1.7861834 661.7501 -3.5770444 663.9592 -3.5770444 Z" fill="#ffffc0"/>
+        <path d="M 663.9592 -3.5770444 L 726.5197 -3.5770444 C 728.7288 -3.5770444 730.5197 -1.7861834 730.5197 .42295564 L 730.5197 19.386415 C 730.5197 21.595554 728.7288 23.386415 726.5197 23.386415 L 663.9592 23.386415 C 661.7501 23.386415 659.9592 21.595554 659.9592 19.386415 L 659.9592 .42295564 C 659.9592 -1.7861834 661.7501 -3.5770444 663.9592 -3.5770444 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(664.9592 .17262947)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="10.424233" y="16">Node</tspan>
+        </text>
+      </g>
+      <g id="Line_31">
+        <line x1="294.35816" y1="128.5251" x2="353.3806" y2="6.963459" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_32">
+        <line x1="431.771" y1="50.58253" x2="376.88925" y2="6.963459" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_33">
+        <line x1="514.92506" y1="38.57521" x2="659.9592" y2="15.514347" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_34">
+        <line x1="704.1647" y1="54.52432" x2="697.9362" y2="23.386415" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_35">
+        <line x1="278.45683" y1="206.12357" x2="207.66283" y2="303.87193" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_36">
+        <line x1="374.2999" y1="370.7293" x2="236.1982" y2="328.94235" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_37">
+        <line x1="755.1013" y1="384.91775" x2="792.9039" y2="506.8969" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_38">
+        <line x1="593.21826" y1="470.93417" x2="744.64765" y2="507.66134" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/0.5/images/diagram-splinter-smartcontractdeployment.svg
+++ b/docs/0.5/images/diagram-splinter-smartcontractdeployment.svg
@@ -1,0 +1,133 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="-204.29167 -122.25 778.953 358.0863" width="778.953" height="358.0863">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-9 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M -8 0 L 0 3 L 0 -3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-02 15:57:16 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_2" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 2</title>
+    <g id="Canvas_2: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_15">
+        <rect x="8.578" y="-45" width="205" height="233.375" fill="white"/>
+        <rect x="8.578" y="-45" width="205" height="233.375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(13.578 -40)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.748" y="33.448">(company A)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_14">
+        <rect x="-197.04167" y="79.375" width="114.622" height="105" fill="#c0ffff"/>
+        <rect x="-197.04167" y="79.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-192.04167 122.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_13">
+        <rect x="21.4765" y="92.25" width="179.1015" height="88.125" fill="#bfffc0"/>
+        <rect x="21.4765" y="92.25" width="179.1015" height="88.125" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(26.4765 97.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="49.72675" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_12">
+        <rect x="47.328" y="122.54167" width="127.5" height="46" fill="#c0ffff"/>
+        <rect x="47.328" y="122.54167" width="127.5" height="46" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(52.328 127.54167)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="37.262" y="15">Smart</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="23.638" y="33.448">Contracts</tspan>
+        </text>
+      </g>
+      <g id="Line_11">
+        <line x1="-82.41967" y1="132.8892" x2="11.57805" y2="134.55261" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_8">
+        <rect x="21.4765" y="14.875" width="179.203" height="65.343994" fill="#bfffc0"/>
+        <rect x="21.4765" y="14.875" width="179.203" height="65.343994" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(26.4765 19.875)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="34.0735" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="362.41133" y="-45" width="205" height="233.375" fill="white"/>
+        <rect x="362.41133" y="-45" width="205" height="233.375" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(367.41133 -40)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.452" y="33.448">(company B)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_6">
+        <rect x="375.30983" y="92.25" width="179.1015" height="88.125" fill="#c0c0ff"/>
+        <rect x="375.30983" y="92.25" width="179.1015" height="88.125" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(380.30983 97.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="49.72675" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_5">
+        <rect x="401.16133" y="121.20833" width="127.5" height="46" fill="#c0ffff"/>
+        <rect x="401.16133" y="121.20833" width="127.5" height="46" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(406.16133 126.20833)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="37.262" y="15">Smart</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="23.638" y="33.448">Contracts</tspan>
+        </text>
+      </g>
+      <g id="Line_3">
+        <line x1="184.72793" y1="145.26414" x2="391.2614" y2="144.48586" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_17">
+        <rect x="375.30983" y="14.875" width="179.203" height="65.343994" fill="#c0c0ff"/>
+        <rect x="375.30983" y="14.875" width="179.203" height="65.343994" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(380.30983 19.875)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="34.0735" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_19">
+        <path d="M -193.04167 -115 L 36.333333 -115 C 38.542472 -115 40.333333 -113.20914 40.333333 -111 L 40.333333 -68.375 C 40.333333 -66.16586 38.542472 -64.375 36.333333 -64.375 L -193.04167 -64.375 C -195.2508 -64.375 -197.04167 -66.16586 -197.04167 -68.375 L -197.04167 -111 C -197.04167 -113.20914 -195.2508 -115 -193.04167 -115 Z" fill="#ffffc0"/>
+        <path d="M -193.04167 -115 L 36.333333 -115 C 38.542472 -115 40.333333 -113.20914 40.333333 -111 L 40.333333 -68.375 C 40.333333 -66.16586 38.542472 -64.375 36.333333 -64.375 L -193.04167 -64.375 C -195.2508 -64.375 -197.04167 -66.16586 -197.04167 -68.375 L -197.04167 -111 C -197.04167 -113.20914 -195.2508 -115 -193.04167 -115 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-192.04167 -109.15161)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="82.8715" y="16">Runtime</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="10.4155" y="35.46411">Smart Contract Deployment</tspan>
+        </text>
+      </g>
+      <g id="Line_18">
+        <line x1="-31.248125" y1="133.79475" x2="-73.01875" y2="-64.375" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_20">
+        <line x1="288.5944" y1="144.87274" x2="288.14098" y2="195.75" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Graphic_22">
+        <path d="M 222.24467 195.75 L 353.74467 195.75 C 355.9538 195.75 357.74467 197.54086 357.74467 199.75 L 357.74467 224.5863 C 357.74467 226.79544 355.9538 228.5863 353.74467 228.5863 L 222.24467 228.5863 C 220.03553 228.5863 218.24467 226.79544 218.24467 224.5863 L 218.24467 199.75 C 218.24467 197.54086 220.03553 195.75 222.24467 195.75 Z" fill="#ffffc0"/>
+        <path d="M 222.24467 195.75 L 353.74467 195.75 C 355.9538 195.75 357.74467 197.54086 357.74467 199.75 L 357.74467 224.5863 C 357.74467 226.79544 355.9538 228.5863 353.74467 228.5863 L 222.24467 228.5863 C 220.03553 228.5863 218.24467 226.79544 218.24467 224.5863 L 218.24467 199.75 C 218.24467 197.54086 220.03553 195.75 222.24467 195.75 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(223.24467 202.4361)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="5.47" y="16">Synchronization</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/0.5/images/diagram-splinter-twopartycircuit.svg
+++ b/docs/0.5/images/diagram-splinter-twopartycircuit.svg
@@ -1,0 +1,245 @@
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="-597.8333 -115.66667 942.8333 397.62797" width="942.8333" height="397.62797">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker_2" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-9 -4 10 8" markerWidth="10" markerHeight="8" color="#7f8080">
+      <g>
+        <path d="M -8 0 L 0 3 L 0 -3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 11 6 4 2 2 2 2 2 4" units-per-em="1000" underline-position="-75" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="975.0061" descent="-216.99524" font-weight="500">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue-Medium"/>
+      </font-face-src>
+    </font-face>
+    <font-face font-family="Helvetica Neue" font-size="13" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.3 
+    <dc:date>2019-10-01 23:12:27 +0000</dc:date>
+  </metadata>
+  <g id="Canvas_3" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>Canvas 3</title>
+    <g id="Canvas_3: Layer 1">
+      <title>Layer 1</title>
+      <g id="Graphic_28">
+        <rect x="-414.25" y="-63" width="205" height="263.75" fill="white"/>
+        <rect x="-414.25" y="-63" width="205" height="263.75" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-409.25 -58)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.748" y="33.448">(company A)</tspan>
+        </text>
+      </g>
+      <g id="Graphic_27">
+        <rect x="-590.5833" y="30.375" width="114.622" height="105" fill="#c0ffc0"/>
+        <rect x="-590.5833" y="30.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-585.5833 73.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_26">
+        <rect x="-402.6875" y="102.75" width="181.875" height="90" fill="#c0ffc0"/>
+        <rect x="-402.6875" y="102.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-397.6875 107.75)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="51.1135" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_25">
+        <rect x="-402.6875" y="-.75" width="181.875" height="90" fill="#c0ffc0"/>
+        <rect x="-402.6875" y="-.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-397.6875 4.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="35.4095" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_23">
+        <rect x="-53.75" y="-63" width="205" height="263.75" fill="white"/>
+        <rect x="-53.75" y="-63" width="205" height="263.75" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-48.75 -58)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="38.668" y="15">Splinter daemon</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="52.452" y="33.448">(company B)</tspan>
+        </text>
+      </g>
+      <g id="Line_17">
+        <line x1="-466.06133" y1="82.875" x2="-437.65" y2="82.875" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_10">
+        <path d="M -578.2723 235.88333 L -578.2723 176.28333 C -578.2723 172.17093 -558.11233 168.83333 -533.27233 168.83333 C -508.43233 168.83333 -488.27233 172.17093 -488.27233 176.28333 L -488.27233 235.88333 C -488.27233 239.99573 -508.43233 243.33333 -533.27233 243.33333 C -558.11233 243.33333 -578.2723 239.99573 -578.2723 235.88333" fill="#c0ffc0"/>
+        <path d="M -578.2723 235.88333 L -578.2723 176.28333 C -578.2723 172.17093 -558.11233 168.83333 -533.27233 168.83333 C -508.43233 168.83333 -488.27233 172.17093 -488.27233 176.28333 L -488.27233 235.88333 C -488.27233 239.99573 -508.43233 243.33333 -533.27233 243.33333 C -558.11233 243.33333 -578.2723 239.99573 -578.2723 235.88333 M -578.2723 176.28333 C -578.2723 180.39573 -558.11233 183.73333 -533.27233 183.73333 C -508.43233 183.73333 -488.27233 180.39573 -488.27233 176.28333" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-573.2723 200.58433)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="5.92" y="15">Database</tspan>
+        </text>
+      </g>
+      <g id="Line_8">
+        <line x1="-338.427" y1="167.04314" x2="-478.56527" y2="195.12195" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_6">
+        <line x1="-533.27233" y1="135.375" x2="-533.27233" y2="158.93333" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_2">
+        <path d="M -338.427 180.4564 L -338.427 142.9396 C -338.427 140.35094 -326.4757 138.25 -311.75 138.25 C -297.0243 138.25 -285.073 140.35094 -285.073 142.9396 L -285.073 180.4564 C -285.073 183.04506 -297.0243 185.146 -311.75 185.146 C -326.4757 185.146 -338.427 183.04506 -338.427 180.4564" fill="#deffd6"/>
+        <path d="M -338.427 180.4564 L -338.427 142.9396 C -338.427 140.35094 -326.4757 138.25 -311.75 138.25 C -297.0243 138.25 -285.073 140.35094 -285.073 142.9396 L -285.073 180.4564 C -285.073 183.04506 -297.0243 185.146 -311.75 185.146 C -326.4757 185.146 -338.427 183.04506 -338.427 180.4564 M -338.427 142.9396 C -338.427 145.52826 -326.4757 147.6292 -311.75 147.6292 C -297.0243 147.6292 -285.073 145.52826 -285.073 142.9396" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-333.427 152.6292)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="2.861" y="15">State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_29">
+        <path d="M -212.4375 241.875 L -50.5625 241.875 C -48.35336 241.875 -46.5625 243.66586 -46.5625 245.875 L -46.5625 270.7113 C -46.5625 272.92044 -48.35336 274.7113 -50.5625 274.7113 L -212.4375 274.7113 C -214.64664 274.7113 -216.4375 272.92044 -216.4375 270.7113 L -216.4375 245.875 C -216.4375 243.66586 -214.64664 241.875 -212.4375 241.875 Z" fill="#ffffc0"/>
+        <path d="M -212.4375 241.875 L -50.5625 241.875 C -48.35336 241.875 -46.5625 243.66586 -46.5625 245.875 L -46.5625 270.7113 C -46.5625 272.92044 -48.35336 274.7113 -50.5625 274.7113 L -212.4375 274.7113 C -214.64664 274.7113 -216.4375 272.92044 -216.4375 270.7113 L -216.4375 245.875 C -216.4375 243.66586 -214.64664 241.875 -212.4375 241.875 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-211.4375 248.5611)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="12.3695" y="16">State Delta Export</tspan>
+        </text>
+      </g>
+      <g id="Graphic_30">
+        <path d="M -184.811 102.5387 L -78.189 102.5387 C -75.97986 102.5387 -74.189 104.32956 -74.189 106.5387 L -74.189 131.375 C -74.189 133.58414 -75.97986 135.375 -78.189 135.375 L -184.811 135.375 C -187.02014 135.375 -188.811 133.58414 -188.811 131.375 L -188.811 106.5387 C -188.811 104.32956 -187.02014 102.5387 -184.811 102.5387 Z" fill="#ffffc0"/>
+        <path d="M -184.811 102.5387 L -78.189 102.5387 C -75.97986 102.5387 -74.189 104.32956 -74.189 106.5387 L -74.189 131.375 C -74.189 133.58414 -75.97986 135.375 -78.189 135.375 L -184.811 135.375 C -187.02014 135.375 -188.811 133.58414 -188.811 131.375 L -188.811 106.5387 C -188.811 104.32956 -187.02014 102.5387 -184.811 102.5387 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-183.811 109.22479)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="4.447001" y="16">Shared State</tspan>
+        </text>
+      </g>
+      <g id="Graphic_31">
+        <path d="M -583.247 -108.41667 L -386.247 -108.41667 C -384.03786 -108.41667 -382.247 -106.6258 -382.247 -104.41667 L -382.247 -79.58036 C -382.247 -77.37122 -384.03786 -75.58036 -386.247 -75.58036 L -583.247 -75.58036 C -585.45614 -75.58036 -587.247 -77.37122 -587.247 -79.58036 L -587.247 -104.41667 C -587.247 -106.6258 -585.45614 -108.41667 -583.247 -108.41667 Z" fill="#ffffc0"/>
+        <path d="M -583.247 -108.41667 L -386.247 -108.41667 C -384.03786 -108.41667 -382.247 -106.6258 -382.247 -104.41667 L -382.247 -79.58036 C -382.247 -77.37122 -384.03786 -75.58036 -386.247 -75.58036 L -583.247 -75.58036 C -585.45614 -75.58036 -587.247 -77.37122 -587.247 -79.58036 L -587.247 -104.41667 C -587.247 -106.6258 -585.45614 -108.41667 -583.247 -108.41667 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-582.247 -101.73057)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="5.468" y="16">Dynamic Circuit Creation</tspan>
+        </text>
+      </g>
+      <g id="Graphic_32">
+        <path d="M -184.811 -21.93469 L -78.189 -21.93469 C -75.97986 -21.93469 -74.189 -20.14383 -74.189 -17.934691 L -74.189 20.961305 C -74.189 23.170444 -75.97986 24.961305 -78.189 24.961305 L -184.811 24.961305 C -187.02014 24.961305 -188.811 23.170444 -188.811 20.961305 L -188.811 -17.934691 C -188.811 -20.14383 -187.02014 -21.93469 -184.811 -21.93469 Z" fill="#ffffc0"/>
+        <path d="M -184.811 -21.93469 L -78.189 -21.93469 C -75.97986 -21.93469 -74.189 -20.14383 -74.189 -17.934691 L -74.189 20.961305 C -74.189 23.170444 -75.97986 24.961305 -78.189 24.961305 L -184.811 24.961305 C -187.02014 24.961305 -188.811 23.170444 -188.811 20.961305 L -188.811 -17.934691 C -188.811 -20.14383 -187.02014 -21.93469 -184.811 -21.93469 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-183.811 -17.950804)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="11.111001" y="16">Consensus</tspan>
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="4.591001" y="35.46411">Coordination</tspan>
+        </text>
+      </g>
+      <g id="Graphic_34">
+        <path d="M 136.75 -108.41667 L 333.75 -108.41667 C 335.95914 -108.41667 337.75 -106.6258 337.75 -104.41667 L 337.75 -79.58036 C 337.75 -77.37122 335.95914 -75.58036 333.75 -75.58036 L 136.75 -75.58036 C 134.54086 -75.58036 132.75 -77.37122 132.75 -79.58036 L 132.75 -104.41667 C 132.75 -106.6258 134.54086 -108.41667 136.75 -108.41667 Z" fill="#ffffc0"/>
+        <path d="M 136.75 -108.41667 L 333.75 -108.41667 C 335.95914 -108.41667 337.75 -106.6258 337.75 -104.41667 L 337.75 -79.58036 C 337.75 -77.37122 335.95914 -75.58036 333.75 -75.58036 L 136.75 -75.58036 C 134.54086 -75.58036 132.75 -77.37122 132.75 -79.58036 L 132.75 -104.41667 C 132.75 -106.6258 134.54086 -108.41667 136.75 -108.41667 Z" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(137.75 -101.73057)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="500" fill="black" x="6.508" y="16">Authorization Delegation</tspan>
+        </text>
+      </g>
+      <g id="Graphic_42">
+        <rect x="-42.1875" y="102.75" width="181.875" height="90" fill="#c0c0ff"/>
+        <rect x="-42.1875" y="102.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-37.1875 107.75)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="51.1135" y="15">Scabbard</tspan>
+        </text>
+      </g>
+      <g id="Graphic_41">
+        <rect x="-42.1875" y="-.75" width="181.875" height="90" fill="#c0c0ff"/>
+        <rect x="-42.1875" y="-.75" width="181.875" height="90" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-37.1875 4.25)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="35.4095" y="15">Admin service</tspan>
+        </text>
+      </g>
+      <g id="Graphic_40">
+        <rect x="-3.372" y="38.46867" width="104.244" height="28.447998" fill="#dde1ff"/>
+        <rect x="-3.372" y="38.46867" width="104.244" height="28.447998" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(1.628 43.46867)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.114002" y="15">Consensus</tspan>
+        </text>
+      </g>
+      <g id="Graphic_38">
+        <rect x="120.375" y="30.375" width="45.503" height="105" fill="#dde1ff"/>
+        <rect x="120.375" y="30.375" width="45.503" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(125.375 67.511)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="1.3844992" y="12">REST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="7.643999" y="27.364">API</tspan>
+        </text>
+      </g>
+      <g id="Graphic_43">
+        <rect x="-427.75" y="30.375" width="45.503" height="105" fill="#deffd6"/>
+        <rect x="-427.75" y="30.375" width="45.503" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-422.75 67.511)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="1.3844992" y="12">REST</tspan>
+          <tspan font-family="Helvetica Neue" font-size="13" font-weight="400" fill="black" x="7.643999" y="27.364">API</tspan>
+        </text>
+      </g>
+      <g id="Graphic_44">
+        <rect x="-363.872" y="40.583333" width="104.244" height="28.447998" fill="#deffd6"/>
+        <rect x="-363.872" y="40.583333" width="104.244" height="28.447998" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(-358.872 45.583333)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.114002" y="15">Consensus</tspan>
+        </text>
+      </g>
+      <g id="Line_36">
+        <line x1="-249.72817" y1="54.44352" x2="-13.27183" y2="53.05648" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_51">
+        <rect x="215.91667" y="30.375" width="114.622" height="105" fill="#c0c0ff"/>
+        <rect x="215.91667" y="30.375" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(220.91667 73.651)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Line_50">
+        <line x1="206.01667" y1="82.875" x2="175.778" y2="82.875" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_52">
+        <line x1="-275.173" y1="161.698" x2="12.173" y2="161.698" marker-end="url(#FilledArrow_Marker)" marker-start="url(#FilledArrow_Marker_2)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_39">
+        <path d="M 22.073 180.4564 L 22.073 142.9396 C 22.073 140.35094 34.024296 138.25 48.75 138.25 C 63.475704 138.25 75.427 140.35094 75.427 142.9396 L 75.427 180.4564 C 75.427 183.04506 63.475704 185.146 48.75 185.146 C 34.024296 185.146 22.073 183.04506 22.073 180.4564" fill="#dde1ff"/>
+        <path d="M 22.073 180.4564 L 22.073 142.9396 C 22.073 140.35094 34.024296 138.25 48.75 138.25 C 63.475704 138.25 75.427 140.35094 75.427 142.9396 L 75.427 180.4564 C 75.427 183.04506 63.475704 185.146 48.75 185.146 C 34.024296 185.146 22.073 183.04506 22.073 180.4564 M 22.073 142.9396 C 22.073 145.52826 34.024296 147.6292 48.75 147.6292 C 63.475704 147.6292 75.427 145.52826 75.427 142.9396" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(27.073 152.6292)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="2.861" y="15">State</tspan>
+        </text>
+      </g>
+      <g id="Line_53">
+        <line x1="189.33333" y1="82.875" x2="230.93907" y2="-75.58036" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_54">
+        <line x1="-453.1113" y1="82.875" x2="-481.77685" y2="-75.58036" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_55">
+        <line x1="-132.00145" y1="53.75294" x2="-131.72508" y2="24.961305" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_56">
+        <line x1="-131.69206" y1="135.375" x2="-132" y2="161.698" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_58">
+        <line x1="-215.37287" y1="243.1577" x2="-479.98534" y2="195.40648" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Graphic_60">
+        <rect x="216.16667" y="30.625" width="114.622" height="105" fill="#c0c0ff"/>
+        <rect x="216.16667" y="30.625" width="114.622" height="105" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(221.16667 73.901)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="12.159001" y="15">Application</tspan>
+        </text>
+      </g>
+      <g id="Graphic_59">
+        <path d="M 228.47767 236.13333 L 228.47767 176.53333 C 228.47767 172.42093 248.63767 169.08333 273.47767 169.08333 C 298.31767 169.08333 318.47767 172.42093 318.47767 176.53333 L 318.47767 236.13333 C 318.47767 240.24573 298.31767 243.58333 273.47767 243.58333 C 248.63767 243.58333 228.47767 240.24573 228.47767 236.13333" fill="#c0c0ff"/>
+        <path d="M 228.47767 236.13333 L 228.47767 176.53333 C 228.47767 172.42093 248.63767 169.08333 273.47767 169.08333 C 298.31767 169.08333 318.47767 172.42093 318.47767 176.53333 L 318.47767 236.13333 C 318.47767 240.24573 298.31767 243.58333 273.47767 243.58333 C 248.63767 243.58333 228.47767 240.24573 228.47767 236.13333 M 228.47767 176.53333 C 228.47767 180.64573 248.63767 183.98333 273.47767 183.98333 C 298.31767 183.98333 318.47767 180.64573 318.47767 176.53333" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(233.47767 200.83433)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="5.92" y="15">Database</tspan>
+        </text>
+      </g>
+      <g id="Line_61">
+        <line x1="273.47767" y1="135.625" x2="273.47767" y2="159.18333" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_62">
+        <line x1="-47.39789" y1="243.4282" x2="221.21045" y2="195.95204" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1.0,4.0" stroke-width="1"/>
+      </g>
+      <g id="Line_63">
+        <line x1="75.427" y1="166.99658" x2="218.76735" y2="195.46679" marker-end="url(#FilledArrow_Marker)" stroke="#7f8080" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This is step 1 of moving the Splinter README's "Features and Concepts" content into the Splinter docs. (The content is identical other than changing the bold phrases to subheadings and adding a missing period.)

Signed-off-by: Anne Chenette <chenette@bitwise.io>