### PR TITLE
Remove unnecessary inline ToCs

### DIFF
--- a/docs/0.4/howto/planning_splinter_deployment.md
+++ b/docs/0.4/howto/planning_splinter_deployment.md
@@ -13,22 +13,6 @@ Splinter works with a wide variety of deployment patterns. This guide summarizes
 how to use Docker containers, a basic Kubernetes pod, and Amazon Elastic
 Kubernetes Services (Amazon EKS).
 
-**Contents**
-<br>
-[Overview](#overview)
-<br>
-[Splinter Architecture](#splinter-architecture)
-<br>
-[Network Configuration](#network-configuration)
-<br>
-[Application Pattern](#application-pattern)
-<br>
-[Docker Deployment](#docker-deployment)
-<br>
-[Basic Kubernetes Deployment](#basic-kubernetes-deployment)
-<br>
-[Amazon EKS Deployment](#amazon-eks-deployment)
-
 ## Overview
 
 A Splinter deployment usually has the following items:

--- a/docs/0.5/howto/planning_splinter_deployment.md
+++ b/docs/0.5/howto/planning_splinter_deployment.md
@@ -13,22 +13,6 @@ Splinter works with a wide variety of deployment patterns. This guide summarizes
 how to use Docker containers, a basic Kubernetes pod, and Amazon Elastic
 Kubernetes Services (Amazon EKS).
 
-**Contents**
-<br>
-[Overview](#overview)
-<br>
-[Splinter Architecture](#splinter-architecture)
-<br>
-[Network Configuration](#network-configuration)
-<br>
-[Application Pattern](#application-pattern)
-<br>
-[Docker Deployment](#docker-deployment)
-<br>
-[Basic Kubernetes Deployment](#basic-kubernetes-deployment)
-<br>
-[Amazon EKS Deployment](#amazon-eks-deployment)
-
 ## Overview
 
 A Splinter deployment usually has the following items:

--- a/releases/0.4/index.md
+++ b/releases/0.4/index.md
@@ -16,20 +16,6 @@ about Splinter concepts and features.
 
 ## New and Noteworthy
 
-Quick links: <br>
-[API stability](#api-stability) <br>
-[Robust circuit support](#robust-circuit-support) <br>
-[Registry for local and remote node
-information](#registry-for-local-and-remote-node-information) <br>
-[Biome for user management](#biome-for-user-management) <br>
-[Scabbard service for smart contract
-execution](#scabbard-service-for-smart-contract-execution) <br>
-[Configuration tools for the Splinter
-daemon](#configuration-tools-for-the-splinter-daemon) <br>
-[Peer management improvements](#peer-management-improvements) <br>
-[Gameroom example application](#gameroom-example-application) <br>
-[... and more](#and-more) <br>
-
 ### API Stability
 
 The Splinter v0.4 release commits to API stability. Changes in future v0.4.x


### PR DESCRIPTION
Removes inline ToCs that are no longer necessary because of the right
sidebar on the website.

The ToC for the docs introduction page is left in-place because it
provides a helpful summary for and transition into the body of the
document.

Signed-off-by: Logan Seeley <seeley@bitwise.io>