### PR TITLE
Move Planning Deployment to Admin section

### DIFF
--- a/_includes/0.4/left_sidebar.html
+++ b/_includes/0.4/left_sidebar.html
@@ -22,7 +22,6 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Getting Started</div>
         <a href="/docs/0.4/">Introduction</a>
-        <a href="/docs/0.4/howto/planning_splinter_deployment.html">Planning a Splinter deployment</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
@@ -35,6 +34,10 @@
         <div class="left-sidebar-header">Example Applications</div>
         <a href="/docs/0.4/examples/gameroom/">Gameroom</a>
         <a href="/docs/0.4/examples/grid_on_splinter.html">Grid on Splinter</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">For Administrators</div>
+        <a href="/docs/0.4/howto/planning_splinter_deployment.html">Planning a Splinter deployment</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>

--- a/_includes/0.5/left_sidebar.html
+++ b/_includes/0.5/left_sidebar.html
@@ -22,7 +22,6 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Getting Started</div>
         <a href="/docs/0.5/">Introduction</a>
-        <a href="/docs/0.5/howto/planning_splinter_deployment.html">Planning a Splinter deployment</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Splinter Concepts</div>
@@ -35,6 +34,10 @@
         <div class="left-sidebar-header">Example Applications</div>
         <a href="/docs/0.5/examples/gameroom/">Gameroom</a>
         <a href="/docs/0.5/examples/grid_on_splinter.html">Grid on Splinter</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">For Administrators</div>
+        <a href="/docs/0.5/howto/planning_splinter_deployment.html">Planning a Splinter deployment</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">For Developers</div>


### PR DESCRIPTION
Create a new "For Administrators" section in the left-nav TOC
and move "Planning a Splinter Deployment" to that section.

Signed-off-by: Anne Chenette <chenette@bitwise.io>