### PR TITLE
Add Capitalization doc guidelines to Community section

### DIFF
--- a/_includes/community/left_sidebar.html
+++ b/_includes/community/left_sidebar.html
@@ -15,6 +15,14 @@
         <a href="/community/stable_feature_checklist.html">Stable Feature Checklist</a>
     </div>
     <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Doc Guidelines</div>
+        <a href="/community/doc_guidelines/general.html">General guidelines</a>
+        <a href="/community/doc_guidelines/clis.html">CLIs</a>
+        <a href="/community/doc_guidelines/rest_apis.html">REST APIs</a>
+        <a href="/community/doc_guidelines/rust_apis.html">Rust APIs</a>
+        <a href="/community/doc_guidelines/capitalization.html">Capitalization</a>
+    </div>
+    <div class="left-sidebar-group">
         <div class="left-sidebar-header">Planning</div>
         <a href="{% link community/planning/features.md %}">Features</a>
     </div>

--- a/community/doc_guidelines/capitalization.md
+++ b/community/doc_guidelines/capitalization.md
@@ -1,0 +1,160 @@
+# Splinter Capitalization Guidelines
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+Use these guidelines to ensure consistency when writing new Splinter
+documentation and updating existing content.
+
+* Follow the [capitalization rules for American
+  English](https://owl.purdue.edu/owl/general_writing/mechanics/help_with_capitals.html).
+
+* See the [Google style guide word
+  list](https://developers.google.com/style/word-list) for capitalization of
+  standard technical terms.
+
+* For software products, companies, and brands, use the official capitalization
+  (see the official website or check [Wikipedia](http://wikipedia.org)).
+
+* For titles and headings, follow the Chicago Manual of Style's title rules.
+  (Tip: Use [capitalizemytitle.com](https://capitalizemytitle.com/) and select
+  "Chicago".)
+
+    - Capitalize the first and the last word, nouns, pronouns, adjectives,
+      verbs, adverbs, and subordinate conjunctions (such as Because, Once,
+      Therefore, When, and Unless).
+
+    - Lowercase articles (a, an, the), coordinating conjunctions, prepositions,
+      and the "to" in infinitive verbs.
+
+* Avoid starting a sentence or title with a lowercase term, such as Splinter
+  commands (CLIs), daemons, and services (such as `splinterd`). Instead,
+  rewrite to start with "The" or some other word.
+
+* To form the plural of an all-uppercase term, add a lowercase "s" with no
+  apostrophe, such as CLIs, IDs, and REST APIs.
+
+[A](#a) - [B](#b) - [C](#c) - D - E - F - [G](#g) - H - [I](#i) - [J](#j) -
+[K](#k) - [L](#l) - [M](#m) - [N](#n) - [O](#o) - [P](#p) - Q - [R](#r) -
+[S](#s) - [T](#x) - U - V - [W](#w) - [X](#x) - [Y](#y) - [Z](#z)
+
+## A
+
+* admin service
+* API, APIs
+* application auth handler _(or application authorization handler)_
+
+## B
+
+* Biome
+
+## C
+
+* Canopy
+* CLI, CLIs
+* consensus
+
+## G
+
+* Gameroom _(example application)_
+* gameroom _(circuit in Gameroom)_
+* `gameroomd` _(daemon; always lowercase)_
+* Grid _(at first use: Hyperledger Grid)_
+* `gridd` _(daemon; always lowercase)_
+
+## I
+
+* ID, IDs
+
+## J
+
+* JavaScript
+* JSON
+
+## K
+
+* key registry _(obsolete; use "registry" or "Splinter registry")_
+
+## L
+
+* `libsplinter` _(always lowercase)_
+
+## M
+
+* Markdown
+* Merkle
+* Merkle-Radix tree
+
+## N
+
+* node
+* node registry _(obsolete; use "registry" or "Splinter registry")_
+
+## O
+
+* OK
+* orchestrator
+
+## P
+
+* PDF _(not "pdf" or ".pdf")_
+* Pike smart contract
+* Private Counter _(obsolete; this example has been removed from Splinter)_
+* Private XO _(obsolete; this example has been removed from Splinter)_
+* Product smart contract
+
+## R
+
+* README, READMEs
+* registry _(at first use: "Splinter registry")_
+* REST API
+* Rust
+
+## S
+
+* Sabre _(at first use: Hyperledger Sawtooth Sabre)_
+* sapling
+* Sawtooth _(at first use: Hyperledger Sawtooth)_
+* scabbard service
+* `scabbard` command _(always lowercase)_
+* SCAR file - smart contract archive file _(not "scar file" or ".scar file")_
+* Schema smart contract
+* SDK, SDKs
+* Seth _(at first use: Hyperledger Sawtooth Seth)_
+* service names: admin service, scabbard service
+* smart contract
+* Splinter
+* `splinter` command _(always lowercase)_
+* `splinter` Rust crate _(always lowercase)_
+* `splinterd` _(daemon; always lowercase)_
+* state
+* state delta export
+
+## T
+
+* tic-tac-toe _(with two hyphens)_
+* TOML file _(not "toml file" or ".toml file")_
+* Transact _(at first use: Hyperledger Transact)_
+* two-phase commit protocol (or "consensus", depending on context) _(avoid "2PC")_
+
+## W
+
+* WASM _(at first use: "WebAssembly (WASM)")_
+* WebAssembly
+
+## X
+
+* XO smart contract
+* `xo` Sawtooth command _(always lowercase)_
+
+## Y
+
+* YAML file, YAML format (not "yaml file" or ".yaml file")
+
+## Z
+
+* ZeroMQ, ZMQ, 0MQ, ØMQ
+


### PR DESCRIPTION
This commit includes a new "Doc Guidelines" section with all planned guidelines (to minimize merge conflicts). Some links will be broken until the other guideline PRs have been merged.

Note: This file contains an internal TOC for increased usability (for those readers who don't notice or use right-nav menus).

Signed-off-by: Anne Chenette <chenette@bitwise.io>