### PR TITLE
Add general doc guidelines to Community section

### DIFF
--- a/_includes/community/left_sidebar.html
+++ b/_includes/community/left_sidebar.html
@@ -15,6 +15,14 @@
         <a href="/community/stable_feature_checklist.html">Stable Feature Checklist</a>
     </div>
     <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Doc Guidelines</div>
+        <a href="/community/doc_guidelines/general.html">General guidelines</a>
+        <a href="/community/doc_guidelines/clis.html">CLIs</a>
+        <a href="/community/doc_guidelines/rest_apis.html">REST APIs</a>
+        <a href="/community/doc_guidelines/rust_apis.html">Rust APIs</a>
+        <a href="/community/doc_guidelines/capitalization.html">Capitalization</a>
+    </div>
+    <div class="left-sidebar-group">
         <div class="left-sidebar-header">Planning</div>
         <a href="{% link community/planning/features.md %}">Features</a>
     </div>

--- a/community/doc_guidelines/general.md
+++ b/community/doc_guidelines/general.md
@@ -1,0 +1,97 @@
+# General Guidelines for Splinter Documentation
+
+<!--
+  Copyright 2018-2020 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+The Splinter documentation guidelines are a work in progress.
+For items not covered here, see
+[plainlanguage.gov](https://www.plainlanguage.gov/guidelines/),
+the [Merriam-Webster's online dictionary](https://www.merriam-webster.com/),
+and the [Google developer documentation style
+guide](https://developers.google.com/style).
+Many thanks to the Google writers who provide this clear, comprehensive guide.
+
+* Be consistent.
+
+* Follow the [Splinter capitalization guidelines](capitalization.md).
+
+* Note these conventions and best practices. (Follow the links for more
+  information in the Google developer documentation style guide.)
+
+    - Use standard American English
+      [spelling](https://developers.google.com/style/spelling),
+      [punctuation](https://developers.google.com/style/semicolons),
+      [capitalization](https://developers.google.com/style/capitalization),
+      and [abbreviations](https://developers.google.com/style/abbreviations).
+
+    - [Use serial commas](https://developers.google.com/style/commas) (also
+      called Oxford commas) before "and" or "or" in lists.
+
+    - [Use "-s" verb forms](https://developers.google.com/style/reference-verbs)
+      in reference documentation, including API and CLI guides, command usage
+      statements (`--help` output), and man pages.
+
+    - [Use present tense](https://developers.google.com/style/tense).
+      Avoid "will", "would", and "shall".
+
+    - [Put conditional clauses before
+      instructions](https://developers.google.com/style/clause-order), not after.
+
+    - [Avoid ambiguous pronoun
+      references](https://developers.google.com/style/pronouns).
+      Ensure that a pronoun clearly refers to its antecedent (the noun that
+      it's replacing).
+
+    - Use appropriate list formatting. [Use numbered
+      lists](https://developers.google.com/style/lists) for ordered sequences.
+      [Use bulleted lists](https://developers.google.com/style/lists) for most
+      other lists.
+
+    - [Use active voice](https://developers.google.com/style/voice). Make clear
+      who's performing an action.
+
+    - [Use second person](https://developers.google.com/style/person) when
+      addressing the reader: "you" rather than "we".
+
+    - [Don't use a filename extension to refer to a type of
+      file](https://developers.google.com/style/word-list#letter-p). Write PDF
+      (not .pdf or pdf), TOML, YAML, and so on.
+
+* For punctuation and font changes, use [Google's text-formatting
+  guidelines](https://developers.google.com/style/text-formatting).
+
+* For wording and terminology, see [Google's Word
+  list](https://developers.google.com/style/word-list).
+
+* Differentiate between code objects and descriptive phrases in the text. (For
+  example, `ConnectionManager` versus "the connection manager".)
+
+    - If possible, use a descriptive phrase instead of a CamelCase code name.
+
+    - Use articles (the, a) with descriptive phrases and put spaces between the
+      words. When using the code name, format it in a constant-width font (using
+      Markdown backticks).
+
+      **Good**: "The connection manager is ..."
+
+      **Good**: "This example uses `ConnectionManager` to ..."
+
+      *Avoid*: "The ConnectionManager is ..."
+
+* Check your spelling.
+
+* Use these [editing
+  strategies](https://writersworkshop.web.illinois.edu/resources-2/writer-resources/writing-processes/editing-and-proofreading/).
+
+* See [George Orwell's six rules for
+  writing](https://en.wikipedia.org/wiki/Politics_and_the_English_Language#Remedy_of_Six_Rules).
+
+> <em>
+> Portions of this page are modifications based on work created and [shared by
+> Google](https://developers.google.com/readme/policies) and used according to
+> terms described in the [Creative Commons 4.0 Attribution
+> License](https://creativecommons.org/licenses/by/4.0/).
+> </em>


### PR DESCRIPTION
This commit includes a new "Doc Guidelines" section with all planned guidelines (to minimize merge conflicts). Some links will be broken until the other guideline PRs have been merged.

Signed-off-by: Anne Chenette <chenette@bitwise.io>