### PR TITLE
Update Grid doc link to point to website

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -55,7 +55,7 @@ contracts.
   `Schema` data type that defines all the possible properties for an item.
 
 For more information, see the [Grid
-documentation.](https://grid.hyperledger.org/docs/grid/nightly/master/)
+documentation](https://grid.hyperledger.org/docs/).
 
 <a href ="https://github.com/hyperledger/grid/blob/master/examples/splinter/README.md"
 type="button" class="btn btn-primary">Try Grid on Splinter ➜</a><br>&nbsp;<br>


### PR DESCRIPTION
On the Splinter Examples page, change the Grid documentation link to go to grid.hyperledger.org/docs/ instead of the grid-docs repo.

Signed-off-by: Anne Chenette <chenette@bitwise.io>