### PR TITLE
Change Dockerfiles to use Node LTS

### DIFF
--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -14,7 +14,7 @@
 
 # -------------=== redoc build ===-------------
 
-FROM node as redoc
+FROM node:lts-stretch as redoc
 
 RUN npm install -g redoc
 RUN npm install -g redoc-cli

--- a/docker/splinter-docs-redoc
+++ b/docker/splinter-docs-redoc
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node
+FROM node:lts-stretch
 
 RUN npm install -g redoc
 RUN npm install -g redoc-cli


### PR DESCRIPTION
The node base image was recently updated causing builds to fail
during installation of redoc. Once the issue described at
https://github.com/Redocly/redoc/issues/1442 is resolved, this
change should be reverted.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>