### PR TITLE
Fix table spacing on roadmap

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -316,7 +316,7 @@ td {
 
 /* Roadmap tables */
 
-#splinter-06 + table, #splinter-08 + p + table {
+#roadmap ~ table {
     width: 100%;
     table-layout: fixed;
 }


### PR DESCRIPTION
This change fixes the table spacing on the roadmap page by making all tables on the page 100% width.  This will make the tables not dependent on the content.
