### PR TITLE
RBAC Documentation

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -321,6 +321,12 @@ td {
     table-layout: fixed;
 }
 
+/* Auth Configuration tables */
+#roles-and-permissions + p + p + table {
+    width: 100%;
+    table-layout: fixed;
+}
+
 /* Landing Page Styles */
 
 #release-banner {

--- a/docs/0.5/howto/configuring_rest_api_authorization.md
+++ b/docs/0.5/howto/configuring_rest_api_authorization.md
@@ -157,3 +157,255 @@ keys that will be granted admin privileges with each one on its own line. The
 file may be updated at any time, even while the node is running. Splinter will
 monitor the file and detect when it's modified, at which point it will reload it
 for an up-to-date list of admin keys.
+
+### Role-based Access Control
+
+Splinter provides a role-based access control (RBAC) system for authorizing
+users and public keys to access various REST API endpoints. Each role is made up
+of a set of permissions.  Identities in the system may have multiple roles.
+
+Note that these permissions only apply to access via the REST API and not other
+aspects of the system, such as smart contract processing.
+
+#### Roles and Permissions
+
+In Splinter, roles define a set of one or more permissions that are granted to
+its members. In the context of the authorization framework, the permissions
+allow access, never deny it.
+
+The available permissions include:
+
+| permission | Description | Routes |
+| ---------- | ----------- | ------ |
+| authorization.maintenance.read | Allows the client to check maintenance mode status | `/authorization/maintenance` |
+| authorization.maintenance.write | Allows the client to enable/disable maintenance mode | `/authorization/maintenance` |
+| authorization.permissions.read | Allows the client to read REST API permissions | `/authorization/permissions` |
+| authorization.rbac.read | Allows the client to read roles, identities, and role assignments | `/authorization/roles`, `/authorization/assignments` |
+| authorization.rbac.write | Allows the client to modify roles, identities, and role assignments | `/authorization/roles`, `/authorization/assignments` |
+| biome.user.read | Allows the client to view all Biome users | `/biome/users` |
+| biome.user.write | Allows the client to modify all Biome users | `/biome/users` |
+| circuit.read | Allows the client to read circuit state | `/admin/circuits`, `/admin/proposals` |
+| circuit.write | Allows the client to modify circuit state | `/admin/circuits`, `/admin/proposals`, `/admin/submit`|
+| health.read | Allows the client to check node health | |
+| registry.read | Allows the client to read the registry | `/registry/nodes` |
+| registry.write | Allows the client to modify the registry |`/registry/nodes` |
+| scabbard.read | Allows the client to read scabbard services' state and batch statuses | `/scabbard/*` |
+| scabbard.write | Allows the client to submit batches to scabbard services | `/scabbard/{circuit}/{service}/batches` |
+| status.read | Allows the client to get node status info | `/status` |
+
+Depending on which features have been compiled into the `splinterd` binary, this
+list may vary. To see the definitive list of permissions for a given `splinterd`
+instance, run the command
+
+```
+$ splinter permissions
+```
+
+Splinter is initialized with a single role, `"admin"`, which has all of the
+permissions.  This role may not be removed via the tools in the following
+section.
+
+##### Configuration
+
+Roles are configured via the `splinter` CLI tool.  All roles are local to a
+splinter node.
+
+###### Viewing Roles
+
+The CLI has two subcommands for displaying information about the existing roles
+on a splinter node: [`splinter role list`]({% link
+docs/0.5/references/cli/splinter-role-list.1.md %}) and [`splinter role
+show`]({% link docs/0.5/references/cli/splinter-role-show.1.md %}).  The `list`
+subcommand displays all of the roles that exist on the node.  The `show`
+subcommand displays details about a specific role, including the set of
+permissions available to members of that role.
+
+For example, the roles can be listed as follows:
+
+```
+$ splinter role list
+ID             NAME
+admin          Administrator
+perm_reader    Permission Reader
+circuit_admin  Circuit Admin
+circuit_reader Circuit Admin
+status_reader  Status Reader
+```
+
+The details for a role can be displayed as follows:
+
+```
+$ splinter role show circuit_admin
+Id: circuit_admin
+    Name: Circuit Admin
+    Permissions:
+        circuit.read
+        circuit.write
+```
+
+###### Creating Roles
+
+Roles are created via the [`splinter role create`]({% link
+docs/0.5/references/cli/splinter-role-create.1.md %}) subcommand.  The roles
+require at least one permission and a display name.  The following example will
+create a role with two permissions.
+
+```
+$ splinter role create \
+    --display "My Role" \
+    --permission status.read \
+    --permission scabbard.read \
+    my_role
+```
+
+The resulting role authorizes members to read both status and scabbard service
+details.
+
+The details for the new role can be displayed via the `show` subcommand:
+
+```
+$ splinter role show circuit_admin
+Id: my_role
+    Name: My Role
+    Permissions:
+        status.read
+        scabbard.read
+```
+
+###### Modifying Roles
+
+Roles are modified via the [`splinter role update`]({% link
+docs/0.5/references/cli/splinter-role-update.1.md %}) subcommand.  A role's
+display name and permissions can both be optionally modified, however the
+requirement that there is still at least one permission stands.
+
+The following example modifies the role created in the previous section, by
+adding one permission and removing another.
+
+```
+$ splinter role update \
+    ---rm-perm status.read \
+    ---add-perm scabbard.write \
+    my_role
+```
+
+The resulting change authorizes members to both read and write scabbard service
+details, but removes the ability to read status information from the node.
+
+###### Deleting roles
+
+Finally, roles are deleted via the [`splinter role delete`]({% link
+docs/0.5/references/cli/splinter-role-delete.1.md %}) subcommand.  Any
+authorized identities will have their membership of that role removed.
+
+The following example deletes the role updated in the previous section.
+
+```
+$ splinter role delete my_role
+```
+
+#### Authorized Identities
+
+From the perspective of the Splinter REST API, identities come in two flavors:
+users and keys. Users are provided via biome or an OAuth2 integration.  Keys are
+Cylinder public keys, provided to the API via a Cylinder JWT.
+
+Identities are authorized via one or more roles. Once the user is authorized,
+the user may make use of the REST API, either via the CLI, or in a browser
+environment.
+
+##### Configuration
+
+Authorized identities are configured via the `splinter` CLI tool. All authorized
+identities are local to a splinter node.
+
+###### Viewing Authorized Identities
+
+The CLI has two subcommands for displaying information about the existing
+authorized identities on a splinter node: [`splinter authid list`]({% link
+docs/0.5/references/cli/splinter-authid-list.1.md %}) and [`splinter authid
+show`]({% link docs/0.5/references/cli/splinter-authid-show.1.md %}).  The
+`list` subcommand displays all of the authorized identities that exist on the
+node.  The `show` subcommand displays details about a specific authorized
+identity, including the set of roles of which the identity is a member.
+
+For example, the authorized identities can be listed as follows:
+
+```
+$ splinter auth list
+IDENTITY                                                           TYPE ROLES
+03d4a6ea6bae775622912b6cf49437098dc3bf06ca49ea331113e27ee0b14c7a3c key  2
+557C80AC-4C17-4A21-9E68-AB9AABD3C8CD                               user 2
+```
+
+The details for an authorized identity can be displayed as follows:
+
+```
+$ splinter authid show --id-user 557C80AC-4C17-4A21-9E68-AB9AABD3C8CD
+ID: 557C80AC-4C17-4A21-9E68-AB9AABD3C8CD
+    Type: user
+    Roles:
+        circuit_reader
+        status_reader
+```
+
+###### Creating Authorized Identities
+
+Authorized identities are created via the [`splinter authid create`]({% link
+docs/0.5/references/cli/splinter-authid-create.1.md %}) subcommand.  An identity
+is either a user id or a public key, one of which is required.  The identity
+must also have at least one role specified.
+
+The following example assigns two roles to a public key (the public key is
+assumed to be in a file, for brevity).
+
+```
+$ splinter authid create \
+    --id-key $(cat ~/.cylinder/keys/my_user.pub) \
+    --role perm_reader \
+    --role circuit_admin
+```
+
+This can be verified via the `show` subcommand:
+
+```
+$ splinter authid show --id-key $(cat ~/.cylinder/keys/my_user.pub)
+ID: 03d4a6ea6bae775622912b6cf49437098dc3bf06ca49ea331113e27ee0b14c7a3c
+    Type: key
+    Roles:
+        circuit_admin
+        perm_reader
+```
+
+###### Modifying Authorized Identities
+
+Authorized identities are updated via the [`splinter authid update`]({% link
+docs/0.5/references/cli/splinter-authid-update.1.md %}) subcommand.  Roles may
+be added or removed, however the identity must still have at least one role
+specified.
+
+The following example removes one role and adds another.
+
+```
+$ splinter authid update \
+    --id-key $(cat ~/.cylinder/keys/my_user.pub) \
+    --rm-role circuit_admin \
+    --add-role circuit_reader
+```
+
+The resulting change removes the identity's ability to administer circuits, but
+still allows it to read them.
+
+###### Deleting Authorized Identities
+
+Finally, authorized identities are deleted via the [`splinter authid delete`]({%
+link docs/0.5/references/cli/splinter-authid-delete.1.md %}) subcommand. An
+identity removed immediately loses its access to any of their permitted REST API
+endpoints.
+
+The following example deletes the public key identity used in the previous
+sections.
+
+```
+$ splinter authid delete --id-key $(cat ~/.cylinder/keys/my_user.pub)
+```

--- a/docs/0.5/references/cli/index.md
+++ b/docs/0.5/references/cli/index.md
@@ -13,6 +13,30 @@ interact with Splinter components.
 [`splinter`]({% link docs/0.5/references/cli/splinter.1.md %})
 Command-line interface for Splinter
 
+### Authorized Identity Management
+[`splinter authid`]({% link docs/0.5/references/cli/splinter-authid.1.md %})
+Provides authorized identity subcommands.
+
+[`splinter authid create`]({% link
+docs/0.5/references/cli/splinter-authid-create.1.md %})
+Creates an authorized identity on a Splinter node.
+
+[`splinter authid delete`]({% link
+docs/0.5/references/cli/splinter-authid-delete.1.md %})
+Deletes an authorized identity on a Splinter node.
+
+[`splinter authid list`]({% link
+docs/0.5/references/cli/splinter-authid-list.1.md %})
+Lists the authorized identities on a Splinter node.
+
+[`splinter authid show`]({% link
+docs/0.5/references/cli/splinter-authid-show.1.md %})
+Shows a specific authorized identity on a Splinter node.
+
+[`splinter authid update`]({% link
+docs/0.5/references/cli/splinter-authid-update.1.md %})
+Updates an authorized identity on a Splinter node.
+
 ### Certificate Management
 [`splinter cert`]({% link docs/0.5/references/cli/splinter-cert.1.md %})
 Provides certificate management subcommands
@@ -81,6 +105,31 @@ Displays information about a Splinter node
 ### Generates user and daemon keys for Splinter
 [`splinter keygen`]({% link docs/0.5/references/cli/splinter-keygen.1.md %})
 Generates user and daemon keys for Splinter
+
+### Role management
+
+[`splinter role`]({% link docs/0.5/references/cli/splinter-role.1.md %})
+Provides role subcommands.
+
+[`splinter role create`]({% link
+docs/0.5/references/cli/splinter-role-create.1.md %})
+Creates a role on a Splinter node.
+
+[`splinter role delete`]({% link
+docs/0.5/references/cli/splinter-role-delete.1.md %})
+Deletes a role on a Splinter node.
+
+[`splinter role list`]({% link docs/0.5/references/cli/splinter-role-list.1.md
+%})
+Lists the roles on a Splinter node.
+
+[`splinter role show`]({% link docs/0.5/references/cli/splinter-role-show.1.md
+%})
+Shows a specific role on a Splinter node.
+
+[`splinter role update`]({% link
+docs/0.5/references/cli/splinter-role-update.1.md %})
+Updates a role on a Splinter node.
 
 ## splinterd CLI
 

--- a/docs/0.5/references/cli/splinter-authid-create.1.md
+++ b/docs/0.5/references/cli/splinter-authid-create.1.md
@@ -1,0 +1,101 @@
+% SPLINTER-AUTHID-CREATE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid-create** — Creates an authorized identity on a Splinter node
+
+SYNOPSIS
+========
+**splinter authid create** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Creates an authorized identity which specifies a set of roles assigned to a
+given identity, either a public key or a user ID, for accessing the REST API on
+a Splinter node. This operation only effects the node itself and not the wider
+network.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+`--id-user` USER-ID
+: Specifies the user identity to authorize. Mutually exclusive to `--id-key`
+
+`--id-key` PUBLIC-KEY
+: Specifies the public key identity to authorize. Mutually exclusive to
+  `--id-user`
+
+`--role` ROLE-ID
+: Specifies a role to be included in the assignment. Specify multiple times for
+  more roles. At least one role is required.
+
+EXAMPLES
+========
+This example creates an authorized identity with two assigned roles.
+
+* The identity has user ID `"user-1234-abcd"`
+* There exists two roles on the system: `circuit_reader` and `status_reader`
+
+```
+$ splinter authid create \
+  --url URL-of-splinterd-REST-API \
+  --role circuit_reader \
+  --role status_reader \
+  --id-user user-1234-abcd
+```
+
+This can be verified by using the `authid show` command:
+
+```
+$ splinter authid show \
+  --url URL-of-splinterd-REST-API \
+  --id-user user-1234-abcd
+ID: user-1234-abcd
+    Type: user
+    roles:
+        circuit_reader
+        status_reader
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-authid-delete(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-show(1)`
+| `splinter-authid-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-authid-delete.1.md
+++ b/docs/0.5/references/cli/splinter-authid-delete.1.md
@@ -1,0 +1,81 @@
+% SPLINTER-AUTHID-DELETE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid-delete** — Deletes an authorized identity on a Splinter node
+
+SYNOPSIS
+========
+**splinter authid delete** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Deletes an existing authorized identity used for accessing the Splinter REST
+API.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+`--id-user` USER-ID
+: Specifies the user identity to delete. Mutually exclusive to `--id-key`
+
+`--id-key` PUBLIC-KEY
+: Specifies the public key identity to delete. Mutually exclusive to `--id-user`
+
+EXAMPLES
+========
+This example deletes an authorized identity with two assigned roles.
+
+* The identity has user ID `"user-1234-abcd"`
+
+```
+$ splinter authid delete \
+  --url URL-of-splinterd-REST-API \
+  --id-user user-1234-abcd \
+```
+
+This can be verified by using the `authid list` command, which will no longer
+list the identity.
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-authid-create(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-show(1)`
+| `splinter-authid-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-authid-list.1.md
+++ b/docs/0.5/references/cli/splinter-authid-list.1.md
@@ -1,0 +1,80 @@
+% SPLINTER-AUTHID-LIST(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid-list** — Displays the existing authorized identities for this
+Splinter node
+
+SYNOPSIS
+========
+**splinter authid list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command lists all of the authorized identities with assigned roles the
+local node has configured. This command displays abbreviated information
+pertaining to assignments in columns, with the headers `ID`, `TYPE`, and
+`ROLES`. This allows the user to quickly see which identities have been assigned
+roles, as well as how many.  The information displayed is only relevant to the
+queried splinter node.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the list. (default `human`). Possible values
+  for formatting are `human` and `csv`.
+
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+This command displays information about authorized identities with a default
+`human` formatting, meaning the information is displayed in a table.  In this
+example, the node is currently configured with a single user identity and a
+single public key identity. The user is assigned to 2 roles; the key is assigned
+to 1
+
+```
+$ splinter role list \
+  --url URL-of-splinterd-REST-API
+IDENTITY                                                           TYPE ROLES
+6596ee05-0997-5897-87be-566c0984f2ec                               user 2
+03d4a6ea6bae775622912b6cf49437098dc3bf06ca49ea331113e27ee0b14c7a3c key  1
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-authid-show.1.md
+++ b/docs/0.5/references/cli/splinter-authid-show.1.md
@@ -1,0 +1,84 @@
+% SPLINTER-AUTHID-SHOW(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid-show** — Displays information about an authorized identity on
+a Splinter node
+
+SYNOPSIS
+========
+**splinter authid show** \[**FLAGS**\] \[**OPTIONS**\] ROLE-ID
+
+DESCRIPTION
+===========
+Display the entire definition of an authorized identity. This definition
+includes the set of roles assigned to the identity.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the authorized identity. (default `human`).
+  Possible values for formatting are `human`, `json`, or `yaml`.
+
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+
+EXAMPLES
+========
+This example shows an authorized identity with two assigned roles.
+
+* The identity has user ID `"user-1234-abcd"`
+* There exists two roles on the system: `circuit_reader` and `status_reader`
+
+```
+$ splinter authid show \
+  --url URL-of-splinterd-REST-API \
+  --id-user user-1234-abcd
+ID: user-1234-abcd
+    Type: user
+    roles:
+        circuit_reader
+        status_reader
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-authid-create(1)`
+| `splinter-authid-delete(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-authid-update.1.md
+++ b/docs/0.5/references/cli/splinter-authid-update.1.md
@@ -1,0 +1,113 @@
+% SPLINTER-AUTHID-UPDATE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid-update** — Updates an authorized identity on a Splinter node
+
+SYNOPSIS
+========
+**splinter authid update** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Updates an existing authorized identity used for accessing the Splinter REST
+API. This command allows the user to change the identity's set of roles.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+`--rm-all`
+: Remove all of the roles currently associated with the authorized identity.
+
+`-f`, `--force`
+: Ignore errors based on duplicate values or adding and removing the same
+  role.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+`--id-user` USER-ID
+: Specifies the user identity to update. Mutually exclusive to `--id-key`
+
+`--id-key` PUBLIC-KEY
+: Specifies the public key identity to update. Mutually exclusive to `--id-user`
+
+`--add-role` ROLE-ID
+: Specifies a role to be added to the authorized identity. Specify multiple
+  times for more roles.
+
+`--rm-role` ROLE-ID
+: Specifies a role to be removed from the authorized identity. Specify multiple
+  times for more roles.
+
+
+EXAMPLES
+========
+This example updates an authorized identity with two assigned roles to remove
+one of the roles and include a new role.
+
+* The identity has user ID `"user-1234-abcd"`
+* The identity is currently assigned roles `circuit_reader` and `status_reader`
+* There exists three roles on the system: `circuit_reader`, `status_reader`, and
+  `circuit_admin`
+
+```
+$ splinter authid update \
+  --url URL-of-splinterd-REST-API \
+  --id-user user-1234-abcd \
+  --rm-role circuit_reader \
+  --add-role circuit_admin
+```
+
+This can be verified by using the `authid show` command:
+
+```
+$ splinter authid show \
+  --url URL-of-splinterd-REST-API \
+  circuit_admin
+ID: circuit_admin
+    Name: Circuit Administrator
+    Permissions:
+        circuit_admin
+        status_read
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-authid-create(1)`
+| `splinter-authid-delete(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-authid.1.md
+++ b/docs/0.5/references/cli/splinter-authid.1.md
@@ -1,0 +1,67 @@
+% SPLINTER-AUTHID(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-authid** — Provides management functions for the Role-Based
+Authorization authorized identities on a Splinter node.
+
+SYNOPSIS
+========
+
+**splinter** **authid** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+
+This command provides subcommands for viewing and modifying role-based access
+assignments for a Splinter daemon.
+
+FLAGS
+=====
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decreases verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`create`
+: Creates an authorized identity on a Splinter node
+
+`delete`
+: Deletes an authorized identity on a Splinter node
+
+`list`
+: Lists the authorized identities on a Splinter node
+
+`show`
+: Shows an authorized identity on a Splinter node
+
+`update`
+: Updates an authorized identity on a Splinter node
+
+SEE ALSO
+========
+| `splinter-authid-create(1)`
+| `splinter-authid-delete(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-show(1)`
+| `splinter-authid-update(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/


### PR DESCRIPTION
This change adds the RBAC documentation to the "Configuring REST API Authorization Section".

It also adds the remaining man pages for the feature.