### PR TITLE
Add feature docs for `circuit-disband` and `circuit-purge`

### DIFF
--- a/community/planning/circuit_disband.md
+++ b/community/planning/circuit_disband.md
@@ -1,0 +1,158 @@
+# Circuit Disband
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+## Summary
+[summary]: #summary
+
+This document presents the design to disband a circuit which enables the
+circuit to be deleted. The ability to delete a circuit affords greater
+flexibility in production and testing environments. Disbanding a circuit is
+dependent on the circuit’s `circuit_status`, which may be `Active`,
+`Disbanded`, or `Abandoned`. Only `Active` circuits are able to be disbanded.
+Once a circuit is created, it has created a network amongst its members and is
+considered `Active`. In order to delete a circuit this networking capability
+must first be removed. As such, disbanding a circuit involves a multi-step
+process to ensure the circuit is removed safely for each node. This feature
+also validates the admin service protocol version and circuit version being
+used, meaning circuits created by nodes running a stable or older Splinter
+release will not be able to use the disband functionality.
+
+Circuit members may take the first step towards removing a circuit entirely
+from state by choosing to disband. A single node may also choose to abandon a
+circuit, which does not take the same considerations as disbanding, but will
+also remove the circuit’s networking capability.
+
+Abandoning a circuit is an alternative route to disbanding a circuit. A node
+may choose to abandon a circuit to disable the circuit's networking from their
+node's perspective. Other circuit members will then be unable to send the
+abandoning node any messages over the abandoned circuit. Disbanding, when
+compared to abandoning, is a safe operation as it requires all members to agree
+before a circuit is completely removed from the network. Once a circuit has
+been disbanded, it is only available locally. This means it has had it’s
+networking capability removed, but the circuit and any service data remains in
+state.
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+### Disbanding a circuit
+
+Disbanding a circuit entails removing a circuit’s networking capabilities.
+Before a circuit is disbanded, however, all members of the circuit must agree
+to disband, following a similar procedure to creating a circuit. A node’s
+administrator may request to disband the circuit, which will create a proposal
+with the new state of the circuit. This newly created proposal then goes
+through validation to ensure the operation is able to be performed. Validating
+the disband request includes the following:
+
+  - The specified circuit in the request is present within the admin store and
+    has a `circuit_status` of `Active`
+  - The protocol version used by the admin services connected to the specified
+    circuit is above 1
+  - The specified circuit in the request has a `circuit_version` of at least 2
+  - The requester’s public key has the correct permission to propose on the
+    associated node
+  - The specified circuit does not already have an associated proposal
+
+Once the disband request has been validated, the proposal is available to all
+circuit members. Then all members are either able to accept or reject the
+proposal. If the proposal is rejected, the proposal is removed and the circuit
+remains active. If the proposal is accepted, the circuit state for all member
+nodes is changed to match the content of the proposal and the networking
+capability of the circuit is switched off. The following section explains this
+procedure in greater detail.
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+### `CircuitDisbandRequest`
+
+For a node’s administrator to request that a circuit is disbanded, a
+`CircuitDisbandRequest` must be first sent to the node’s admin service. The
+`CircuitDisbandRequest` is defined as follows:
+
+```
+message CircuitDisbandRequest {
+    // The unique circuit name
+    string circuit_id = 1;
+}
+```
+
+This request is then wrapped in a `CircuitManagementPayload` before being
+submitted to the admin service. `CircuitManagementPayload`s are used for
+various actions pertaining to creating and now deleting a circuit. The
+`CircuitManagementPayload` for a disband request would appear as follows:
+
+```
+message CircuitManagementPayload {
+    header =
+        Header {
+            action = CIRCUIT_DISBAND_REQUEST;
+            requester = <Bytes of the requester’s public key>;
+            payload_sha512 = <Bytes of the hash of the payload’s action>;
+            requester_node_id = <Node ID of the requester submitting the payload>;
+        }
+    signature = <Signature of the header included in the request>;
+    circuit_disband_request = <`CircuitDisbandRequest` with the circuit ID of the circuit to be disbanded>;
+}
+```
+
+### Handling the `CircuitDisbandRequest`
+
+Once this request has been submitted to the admin service, the admin service
+validates the payload based on the guidelines explained previously. If the
+payload is successfully validated, the admin service creates a
+`CircuitProposal` to represent the disbanded state of the circuit and makes
+this proposal available to other nodes. This proposal is the same type of
+proposal used when creating a circuit, except the `ProposalType` is `Disband`.
+The circuit (being disbanded) defined within the proposal also has the same
+information as the existing active circuit, except with a `circuit_status` of
+`Disbanded`.
+
+#### Voting on the disband proposal
+
+Voting on this proposal follows the same procedure as when voting to create a
+circuit. That is, all members must first vote to accept the proposal to disband
+the circuit before the circuit state is updated. If any circuit members vote to
+reject the proposal, the proposal will be removed from the admin store and the
+circuit will remain active. If the proposal to disband is accepted, however,
+the circuit state will be updated for each of the circuit members to reflect
+the `disbanded` state. This also means the circuit’s networking is turned off.
+
+#### Result of disbanding
+
+Specifically, the ability of the nodes to communicate over the circuit will no
+longer be available. On disband, each node will remove the references to the
+peers from the circuit and remove the circuit from the admin service’s
+`RoutingTable`. This will disable messages from being able to be sent over the
+disbanded circuit. Disbanding a circuit also includes stopping the services
+that were running on the circuit. The admin service for each node uses the
+`ServiceOrchestrator` to stop the circuit’s associated services. This operation
+will only stop internal services, and does not have any effect on services
+running externally. These services must be stopped externally. Any operations
+attempted on the disbanded circuit via a Splinter service will ultimately fail
+as all services have been stopped once the circuit is disbanded.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+Removing a circuit from its networking capabilities may cause concern for node
+administrators. As such, the disband feature allows time for each system
+administrator to come to a decision externally before agreeing to disband a
+circuit. This also gives administrators the option to reject the disbanding, to
+ensure each administrator has full control over the state of their Splinter
+network. Disbanding a circuit is a relatively safe operation.
+
+## Prior art
+[prior-art]: #prior-art
+
+Prior to this feature, circuit deletion has not been implemented. The process
+of the disband feature does follow the design used to create a circuit, using
+the `CircuitCreate` message.
+
+## Unresolved questions
+[unresolved]: #unresolved

--- a/community/planning/circuit_purge.md
+++ b/community/planning/circuit_purge.md
@@ -1,0 +1,123 @@
+# Circuit Purge
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+## Summary
+[summary]: #summary
+
+This document presents the design to enable purging a circuit from state,
+including any Splinter service data related to the circuit. Being able to
+delete state related to a circuit enables Splinter users to more easily maintain
+and clean up any unused circuit data. The ability to purge a circuit is
+validated against the circuit’s `circuit_status`. A circuit may be `Active`,
+`Disbanded`, or `Abandoned`. Circuits that have become `Disbanded` or
+`Abandoned` may be purged while `Active` circuits cannot. Purging a circuit
+includes removing the circuit state as well as Splinter’s service data. Once
+the circuit has been purged, it is no longer available from Splinter. This
+action is only available for circuits that are no longer active to protect
+circuits that are still active, and presumably being used, from having any data
+unnecessarily removed. As functionality to deactivate a circuit is implemented,
+the ability to purge the data leftover from these inactive circuits is
+necessary to allow users the freedom to handle this data as they choose.
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+### Purging a circuit
+
+Once a circuit has been disbanded or abandoned, it is only available to each
+node locally. Either of these operations essentially deactivates a circuit,
+making it available to be purged. In order to remove this state, i.e. remove
+the circuit from the admin store as well as remove any storage files related to
+the Splinter service, a circuit may be purged. A circuit is purged from each
+node individually, upon a node’s administrator's request. This means the state
+for each node previously associated with the disbanded circuit will not change
+until an administrator of that specific node requests to purge the circuit. A
+purge request is verified by the admin service using the following criteria:
+
+  - The requester has the correct permissions for the node the circuit is being
+    purged from
+  - The circuit is present in the admin store and has a `circuit_status` that
+    is not `Active`
+  - The specified circuit in the request has a `circuit_version` of at least 2
+
+Once the purge request has been validated by the admin service, the circuit and
+service state are removed from storage. This includes removing the circuit’s
+entry from the admin store. Splinter service data, specifically Scabbard’s LMDB
+files, are also removed by the purge request. The circuit will be removed
+from state for the requesting node. All other members of the circuit would
+still be able to access and view the circuit or service state. The node that
+has purged the circuit, however, will be unable to view the circuit or service
+data via Splinter.
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+### `CircuitPurgeRequest`
+
+A `CircuitPurgeRequest` may be submitted to remove the state of an inactive
+circuit. An inactive circuit is a circuit with a `circuit_status` besides
+`Active`. This may follow either a `CircuitDisbandRequest` or a
+`CircuitAbandonRequest`. The `CircuitDisbandRequest` is further explained in
+the [Circuit Disband]({% link community/planning/circuit_disband.md %}) feature
+document and ultimately creates a circuit with a `Disbanded` `circuit_status`.
+The `CircuitAbandonRequest` enables a circuit to have a `circuit_status` of
+`Abandoned`. In both of these cases, the circuit networking will have been
+turned off. Once the circuit has been disbanded or abandoned, it is able to be
+purged.
+
+The `CircuitPurgeRequest` is defined in the admin protos as follows:
+
+```
+message CircuitPurgeRequest {
+    // The unique circuit id of the inactive circuit to be purged
+    string circuit_id = 1;
+}
+```
+This request is also wrapped in a `CircuitManagementPayload` before being
+submitted to the admin service. This payload would appear as follows:
+
+```
+message CircuitManagementPayload {
+    header =
+        Header {
+            action = CIRCUIT_PURGE_REQUEST;
+            requester = <Bytes of the requester’s public key>;
+            payload_sha512 = <Bytes of the hash of the payload’s action>;
+            requester_node_id = <Node ID of the requester submitting the payload>;
+        }
+    signature = <Signature of the header included in the request>;
+    circuit_purge_request = <`CircuitPurgeRequest` with the circuit ID of the circuit to be purged>;
+}
+```
+
+Once this payload is submitted to the admin service, the request is validated.
+The steps for validation are described in the previous section. If the purge
+request is invalid, the circuit and service state will remain. If the purge
+request is successfully validated, the circuit will then be removed from the
+admin store. The admin service then uses the `ServiceOrchestrator`’s
+`purge_service` method, which uses the service’s defined `purge` method to
+delete the service data. In Scabbard, the `purge` method will remove the LMDB
+files associated with the `ScabbardState`. Any service data from services
+managed externally must be also deleted externally. The purge request will
+remove all data pertaining to the circuit from Splinter’s state.
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+Purging a circuit is only available to inactive circuits, i.e. circuits that
+have previously been disbanded or abandoned. This feature does not enable a
+user to remove the circuit’s networking and delete all state data related to
+that circuit in a single command.
+
+## Prior art
+[prior-art]: #prior-art
+
+Prior to this feature, circuit deletion has not been implemented. Therefore,
+this design does not follow prior art.
+
+## Unresolved questions
+[unresolved]: #unresolved

--- a/community/planning/features.md
+++ b/community/planning/features.md
@@ -31,7 +31,7 @@ forum.
 
 Features listed here are no longer being worked on, either because they have
 been completed or abandoned. These documents represent the the intended design
-at the time the features were implemented. Due to Spinter's rapid development,
+at the time the features were implemented. Due to Splinter's rapid development,
 the current state of these features may differ somewhat from the original
 design.
 

--- a/community/planning/features.md
+++ b/community/planning/features.md
@@ -22,6 +22,7 @@ forum.
 | [Admin UI Profile Redesign]({% link community/planning/admin_ui_profile.md %}) | New designs for the profile page in the splinter Admin UI |
 | [Canopy 0.2]({% link community/planning/canopy_0.2.md %}) | New design of the Canopy system that enables dynamic loading of saplings and improved inter-sapling communication |
 | [Capabilities Repository]({% link community/planning/capabilities-repository.md %}) | A design for a repository and all the surrounding tools and formats for Splinter artifacts. These artifacts include saplings, smart contracts, and capabilities distributions. |
+| [Circuit Disband]({% link community/planning/circuit_disband.md %}) | Design for removing a circuit's networking capabilities |
 | [REST API Authorization]({% link community/planning/rest_api_authorization.md %}) | Design for securing the Splinter REST API |
 | [REST API Maintenace Mode]({% link community/planning/rest_api_maintenance_mode.md %}) | Design for the maintenance mode authorization handler for the Splinter REST API |
 

--- a/community/planning/features.md
+++ b/community/planning/features.md
@@ -23,6 +23,7 @@ forum.
 | [Canopy 0.2]({% link community/planning/canopy_0.2.md %}) | New design of the Canopy system that enables dynamic loading of saplings and improved inter-sapling communication |
 | [Capabilities Repository]({% link community/planning/capabilities-repository.md %}) | A design for a repository and all the surrounding tools and formats for Splinter artifacts. These artifacts include saplings, smart contracts, and capabilities distributions. |
 | [Circuit Disband]({% link community/planning/circuit_disband.md %}) | Design for removing a circuit's networking capabilities |
+| [Circuit Purge]({% link community/planning/circuit_purge.md %}) | Design for removing a circuit's state data |
 | [REST API Authorization]({% link community/planning/rest_api_authorization.md %}) | Design for securing the Splinter REST API |
 | [REST API Maintenace Mode]({% link community/planning/rest_api_maintenance_mode.md %}) | Design for the maintenance mode authorization handler for the Splinter REST API |
 

--- a/docs/0.5/references/api/openapi.yml
+++ b/docs/0.5/references/api/openapi.yml
@@ -27,7 +27,10 @@ paths:
     get:
       tags:
         - diagnostics
-      description: Used to check if server is successfully running
+      description: |
+        Used to check if server is successfully running
+
+        This endpoint requires the permission "status.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -58,6 +61,8 @@ paths:
         provided via the "member" query parameter, only circuit proposals that
         have the given node as a member will be returned. If no filter is
         provided, all of the node's circuit proposals will be returned.
+
+        This endpoint requires the permission "circuit.read".
       tags:
         - Proposals
       parameters:
@@ -128,6 +133,8 @@ paths:
       description: |
         This endpoint can be used to view a specific circuit proposal that the
         node is a proposed member of.
+
+        This endpoint requires the permission "circuit.read".
       tags:
         - Proposals
       parameters:
@@ -165,7 +172,10 @@ paths:
     post:
       tags:
         - Admin Service
-      description: Send circuit management payload in bytes to admin service
+      description: |
+        Send circuit management payload in bytes to admin service
+
+        This endpoint requires the permission "circuit.write".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -199,7 +209,10 @@ paths:
     get:
       tags:
         - Admin Service
-      description: Register the handler for a circuit management type
+      description: |
+        Register the handler for a circuit management type
+
+        This endpoint requires the permission "circuit.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -251,6 +264,8 @@ paths:
         parameter, only circuits that have the given circuit status will be
         returned; if no filter is provided, all of the node's `Active` circuits
         will be returned.
+
+        This endpoint requires the permission "circuit.read".
       tags:
         - Circuits
       parameters:
@@ -317,6 +332,8 @@ paths:
       description: |
         This endpoint can be used to view a specific circuit that the node is a
         member of.
+
+        This endpoint requires the permission "circuit.read".
       tags:
         - Circuits
       parameters:
@@ -354,7 +371,10 @@ paths:
     get:
       tags:
         - Authorization
-      description: Checks whether or not maintenance mode is enabled
+      description: |
+        Checks whether or not maintenance mode is enabled
+
+        This endpoint requires the permission "authorization.maintenance.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -376,7 +396,10 @@ paths:
     post:
       tags:
         - Authorization
-      description: Sets whether or not maintenance mode is enabled
+      description: |
+        Sets whether or not maintenance mode is enabled
+
+        This endpoint requires the permission "authorization.maintenance.write".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -412,7 +435,10 @@ paths:
       tags:
         - Authorization
         - Permissions
-      description: Fetches the list of all REST API permissions
+      description: |
+        Fetches the list of all REST API permissions
+
+        This endpoint requires the permission "authorization.permissions.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -497,11 +523,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     post:
+      tags:
+        - Roles
+        - Permissions
+        - RBAC
+        - Authorization
       summary: Add a role
       description: |
         This endpoint can be used to add a new role to the Splinter Role-based
         authorization system. The role must conform to the role schema and have
         unique "role_id" value.
+
+        This endpoint requires the permission "authorization.rbac.write".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -534,6 +567,8 @@ paths:
       summary: Fetches a role by its ID
       description: |
         This endpoint can be used to view a specific role.
+
+        This endpoint requires the permission "authorization.rbac.read".
       tags:
         - Roles
       parameters:
@@ -577,6 +612,8 @@ paths:
         This endpoint can be used to add a new node to the Splinter registry.
         The node must be valid (see the Splinter registry documentation for
         details on node validity).
+
+        This endpoint requires the permission "registry.write".
       tags:
         - Splinter Registry
       parameters:
@@ -613,6 +650,8 @@ paths:
         registry. If metadata filters are provided via the "filter" query
         parameter, only nodes that match the given filters will be returned. See
         the Splinter registry documentation for details on metadata filters.
+
+        This endpoint requires the permission "registry.read".
       tags:
         - Splinter Registry
       parameters:
@@ -676,6 +715,8 @@ paths:
       summary: Fetch a node in the registry by its identity
       description: |
         This endpoint can be used to view a specific nodes in the registry.
+
+        This endpoint requires the permission "registry.read".
       tags:
         - Splinter Registry
       parameters:
@@ -718,6 +759,8 @@ paths:
         This endpoint can be used to add a new node to the registry, or replace
         an existing node. When replacing an existing node, the node identity
         cannot be changed. This action is idempotent.
+
+        This endpoint requires the permission "registry.write".
       tags:
         - Splinter Registry
       parameters:
@@ -755,7 +798,10 @@ paths:
 
     delete:
       summary: Delete a node from the registry
-      description: This endpoint can be used to remove a node from the registry.
+      description: |
+        This endpoint can be used to remove a node from the registry.
+
+        This endpoint requires the permission "registry.write".
       tags:
         - Splinter Registry
       parameters:
@@ -793,6 +839,8 @@ paths:
         body of the request must be a list of valid Sabre batches. If the
         batches are submitted successfully, the response will contain a link for
         checking the status of the submitted batches.
+
+        This endpoint requires the permission "scabbard.write".
       tags:
         - Scabbard
       parameters:
@@ -850,6 +898,8 @@ paths:
         query parameter requests that the server wait for the given number of
         seconds for the batches to be committed; however, this wait time is not
         guaranteed.
+
+        This endpoint requires the permission "scabbard.read".
       tags:
         - Scabbard
       parameters:
@@ -930,6 +980,8 @@ paths:
         This endpoint can be used to fetch a list of entries from a Scabbard
         service's state. The entries can be filtered using an address prefix
         provided with the `prefix` query parameter.
+
+        This endpoint requires the permission "scabbard.read".
       tags:
         - Scabbard
       parameters:
@@ -1001,6 +1053,8 @@ paths:
       description: |
         This endpoint can be used to fetch the value at a specific address in a
         Scabbard service's state.
+
+        This endpoint requires the permission "scabbard.read".
       tags:
         - Scabbard
       parameters:
@@ -1324,7 +1378,10 @@ paths:
     get:
       tags:
         - Biome
-      description: Lists all users
+      description: |
+        Lists all users
+
+        This endpoint requires the permission "biome.user.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1359,7 +1416,10 @@ paths:
     get:
       tags:
       - Biome
-      description: Fetch a user by ID
+      description: |
+        Fetch a user by ID
+
+        This endpoint requires the permission "biome.user.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1409,7 +1469,10 @@ paths:
     put:
       tags:
       - Biome
-      description: Update a user
+      description: |
+        Update a user
+
+        This endpoint requires the permission "biome.user.write".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1485,7 +1548,10 @@ paths:
     delete:
       tags:
         - Biome
-      description: Delete a user
+      description: |
+        Delete a user
+
+        This endpoint requires the permission "biome.user.write".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1526,7 +1592,10 @@ paths:
     get:
       tags:
         - Biome
-      description: List all user profiles
+      description: |
+        List all user profiles
+
+        This endpoint requires the permission "biome.user.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"
@@ -1552,7 +1621,10 @@ paths:
     get:
       tags:
       - Biome
-      description: Fetch a profile by ID
+      description: |
+        Fetch a profile by ID
+
+        This endpoint requires the permission "biome.user.read".
       parameters:
         - $ref: "#/components/parameters/auth"
         - $ref: "#/components/parameters/protocol_version"

--- a/docs/0.5/references/cli/splinter-circuit-disband.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-disband.1.md
@@ -90,5 +90,6 @@ SEE ALSO
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-show(1)`
+| `splinter-circuit-purge(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-circuit-purge.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-purge.1.md
@@ -1,0 +1,85 @@
+% SPLINTER-CIRCUIT-PURGE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-purge** — Submits a request to purge the specified circuit.
+
+SYNOPSIS
+========
+**splinter circuit purge** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID
+
+DESCRIPTION
+===========
+Request to purge a circuit by specifying the circuit ID of the circuit to be
+removed from the node's storage. A circuit is only available to be purged
+if it has already been disbanded and are only available locally. Disbanding a
+circuit removes a circuit's networking functionality.
+
+The generated ID of the existing disbanded circuit can be viewed using the
+`splinter-circuit-list`, with the `--circuit-status` option of `disbanded`.
+
+The purge request is only available for members of the node, as the circuit is
+only available to the node locally. If the circuit has not been disbanded, it
+is not able to be purged. Once a circuit has been purged, it is removed from
+the node's storage and is no longer viewable.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information.
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information.
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be purged.
+
+EXAMPLES
+========
+* The existing disbanded circuit has ID `1234-ABCDE`.
+
+The following command displays a member node requesting to purge the circuit:
+```
+$ splinter circuit purge \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
+  1234-ABCDE \
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-list(1)`
+| `splinter-circuit-disband(1)`
+| `splinter-circuit-show(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-circuit-show.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-show.1.md
@@ -84,7 +84,7 @@ $ splinter circuit show 01234-ABCDE \
 Proposal to create: 01234-ABCDE
     Display Name: -
     Circuit Status: Active
-    Version: 2
+    Schema Version: 2
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)
@@ -119,7 +119,7 @@ $ splinter circuit show 01234-ABCDE \
 Proposal to disband: 56789-ABCDE
     Display Name: Circuit1
     Circuit Status: Disbanded
-    Version: 2
+    Schema Version: 2
     Management Type: mgmt001
 
     alpha-001 (tcps://splinterd-node-alpha001:8044)

--- a/docs/0.5/references/cli/splinter-registry-add.1.md
+++ b/docs/0.5/references/cli/splinter-registry-add.1.md
@@ -1,0 +1,133 @@
+% SPLINTER-REGISTRY-ADD(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-registry-add** — Add a node to the local registry
+
+SYNOPSIS
+========
+
+**splinter registry add** \[**FLAGS**\] \[**OPTIONS**\] IDENTITY
+
+DESCRIPTION
+===========
+
+Add a new node to the local node registry. The node may be entirely new to the
+registry, or it may be copied from the remote registries with the
+`--from-remote` flag. If the `--from-remote` flag is used the `--display-name`,
+`--endpoint`, `--key` and `--metadata` options may not be used to alter the
+node being copied from the remote registry. When run, the command will
+display the resulting changes as confirmation.
+
+FLAGS
+=====
+`--dry-run`
+: Shows the expected changes without submitting the node.
+
+`--from-remote`
+: Copies an existing node definition from the remote registries. 
+
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decreases verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+
+`--display-name` DISPLAY_NAME
+: Sets a human-readable name for the new node. If not provided, a default value
+based on the node's ID will be used.
+
+`--endpoint ENDPOINT`
+: Adds a network endpoint for the new node. At least one endpoint must be
+provided, and all endpoints must be non-empty and unique in the registry (two
+nodes cannot share the same endpoint). Repeat this option to specify multiple
+endpoints.
+
+`--key-file KEY`
+: Add the public key to the new node. At least one key must be provided, and all
+keys must be non-empty. Repeat this option to specify multiple keys.
+
+`-k`, `--key KEY`
+: Name or path of private key to be used for REST API authorization.
+
+`--metadata METADATA_STRING`
+: Adds the metadata to the new node, using the format
+`METADATA_KEY:METADATA_VALUE`. If an entry for the given `METADATA_KEY` already
+exists, it will be replaced. Repeat this option to specify multiple metadata
+entries.
+
+`-U`, `--url URL`
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+
+`IDENTITY`
+Identity of the new node. Must be unique in the local registry.
+
+EXAMPLES
+========
+
+The simplest use of this command is to create a new node with an identity, a
+single endpoint, and a single key:
+
+```
+splinter registry add example-node-1 \
+  --endpoint tcps://splinterd-node-1:8044 \
+  --key /path/to/public/key/file \
+  --url http://splinterd-rest-api:8085
+```
+
+Multiple endpoints, keys, and metadata entries can be provided by specifying the
+arguments multiple times:
+
+```
+splinter registry add example-node-2 \
+  --endpoint tcps://splinterd-node-2:8044 \
+  --endpoint tcp://splinterd-node-2:8045 \
+  --key /path/to/public/key/file1 \
+  --key /path/to/public/key/file2 \
+  --metadata key1:value1 \
+  --metadata key2:value2 \
+  --url http://splinterd-rest-api:8085
+```
+
+A node that exists in one or more remote registries can be copied to the local
+registry with just the node's identity and the `--from-remote` flag, the
+`--display-name`, `--endpoint`, `--key` and `--metadata` options may not be used
+with this flag:
+
+```
+splinter registry add example-node-3 \
+  --from-remote \
+  --url http://splinterd-rest-api:8085
+```
+
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter.1.md
+++ b/docs/0.5/references/cli/splinter.1.md
@@ -85,9 +85,11 @@ Many `splinter` subcommands accept the following environment variable:
 SEE ALSO
 ========
 | `splinter-cert-generate(1)`
+| `splinter-circuit-disband(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
 | `splinter-circuit-propose(1)`
+| `splinter-circuit-purge(1)`
 | `splinter-circuit-show(1)`
 | `splinter-circuit-template-arguments(1)`
 | `splinter-circuit-template-list(1)`

--- a/docs/0.5/references/cli/splinterd.1.md
+++ b/docs/0.5/references/cli/splinterd.1.md
@@ -63,11 +63,6 @@ information, see `--config-dir`, `--tls-cert-dir`, and
 FLAGS
 =====
 
-`--enable-biome`
-: Enable the Biome subsystem, which provides user management functions for
-  Splinter applications. The `--database` option is required when this flag is
-  used.
-
 `-h`, `--help`
 : Prints help information.
 
@@ -340,9 +335,6 @@ signing algorithms provided by the Cylinder library. This includes secp256k1
 which is currently used for signing transactions and Splinter administrative
 payloads. This allows the same signing key to be used as an authorization
 identity.
-
-Biome credentials for the splinter REST API can be enabled using the
-`--enable-biome` flag.
 
 The Splinter daemon provides 5 options for configuring OAuth for the REST API:
 


### PR DESCRIPTION
This PR adds feature documents for the `circuit-disband` and `circuit-purge` features. Also, adds the documents generated by the command `just copy-docs` which pulls in the `splinter-circuit-purge` CLI man page, as well as other updates from Splinter man pages and OpenAPI spec.