### PR TITLE
Remove disband & purge feature doc empty sections

### DIFF
--- a/community/planning/circuit_disband.md
+++ b/community/planning/circuit_disband.md
@@ -153,6 +153,3 @@ network. Disbanding a circuit is a relatively safe operation.
 Prior to this feature, circuit deletion has not been implemented. The process
 of the disband feature does follow the design used to create a circuit, using
 the `CircuitCreate` message.
-
-## Unresolved questions
-[unresolved]: #unresolved

--- a/community/planning/circuit_purge.md
+++ b/community/planning/circuit_purge.md
@@ -118,6 +118,3 @@ that circuit in a single command.
 
 Prior to this feature, circuit deletion has not been implemented. Therefore,
 this design does not follow prior art.
-
-## Unresolved questions
-[unresolved]: #unresolved


### PR DESCRIPTION
Removes the empty 'Unresolved Questions' section of the `Circuit
Disband` and `Circuit Purge` feature documents. Feature documents do not
have as rigid a format, so this empty section may be omitted.

Signed-off-by: Shannyn Telander <telander@bitwise.io>