### PR TITLE
Add Circuit-Abandon feature document

### DIFF
--- a/community/planning/circuit_abandon.md
+++ b/community/planning/circuit_abandon.md
@@ -1,0 +1,130 @@
+# Circuit Abandon
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+## Summary
+[summary]: #summary
+
+This document presents the design for abandoning a circuit. A node’s
+administrator may choose to abandon a circuit, removing the circuit’s
+networking capability from that node’s perspective, without validation from
+other circuit members. This retains the circuit state for all nodes as well as
+any Splinter service data. It does update the circuit state for the abandoning
+node to show the `Abandoned` status of the circuit, however, and removes the
+circuit’s networking. Circuits may also have a status of `Active` and
+`Disbanded`. Only `Active` circuits are able to be abandoned. If circuit
+members attempt to reach the node that abandoned the circuit, via the circuit
+that was abandoned, the request will fail as that circuit will no longer be
+able to route the message accordingly. The abandon functionality enables
+individual circuit members to leave a circuit if they so choose.
+
+The alternative to abandoning a circuit is disbanding. Disbanding a circuit is
+considered a safer alternative to abandoning a circuit, as it performs
+relatively the same function to remove a circuit’s networking capability, but
+the process includes all circuit members. The [Circuit Disband]({%
+link community/planning/circuit_disband.md %}) feature document contains more
+information on this alternative approach.
+
+## Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+### Abandoning a circuit
+
+Abandoning a circuit will remove a circuit’s networking capabilities for the
+requesting node and disables other members from reaching the node via the
+circuit that was abandoned. This request is validated by the admin service
+using the following criteria:
+
+ - The circuit to be abandoned exists and has a `circuit_status` of `Active`
+ - The requester has the correct permissions for the node the circuit is being
+   abandoned on
+ - The specified circuit in the request has a `circuit_version` of at least 2
+
+If the request to abandon a circuit passes this validation, the node’s admin
+service will update the circuit definition and stop any of the node’s services
+running on the circuit. In terms of the circuit state update, the circuit
+stored by the abandoning node is updated to show the `Abandoned`
+`circuit_status`. As this request does not require validation from other
+circuit members, this operation’s changes are only local to the requesting node.
+
+All other members of the circuit, if multiple peers remain, are able to
+communicate over the circuit. However, no members of the circuit will be able
+to communicate, via messages, over the circuit to the abandoning node.
+
+After a circuit has been abandoned it is then able to be purged. This means all
+state associated with the abandoned circuit will be removed. Further
+information on the purge functionality may be found in the [Circuit Purge](
+{% link community/planning/circuit_purge.md %}) feature document.
+
+## Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+### `CircuitAbandon`
+
+To abandon a circuit, first a `CircuitAbandon` message must be created. The
+definition of this protobuf message follows:
+
+```
+message CircuitAbandon {
+    // The unique circuit name
+    string circuit_id = 1;
+}
+```
+This message is then wrapped in a `CircuitManagementPayload` before being
+submitted to the admin service. This payload would appear as follows:
+
+```
+message CircuitManagementPayload {
+    header =
+        Header {
+            action = CIRCUIT_ABANDON;
+            requester = <Bytes of the requester’s public key>;
+            payload_sha512 = <Bytes of the hash of the payload’s action>;
+            requester_node_id = <Node ID of the requester submitting the payload>;
+        }
+    signature = <Signature of the header included in the request>;
+    circuit_abandon = <`CircuitAbandon` with the circuit ID of the circuit to be abandoned>;
+}
+```
+This message is then submitted to the admin service where it is validated using
+the criteria explained previously. If the abandon request is successfully
+validated, the admin service proceeds by disabling the circuit from the
+abandoning node’s perspective. This includes updating the circuit state to the
+same information stored in the previously active circuit, but with the
+`circuit_status` of `Abandoned`. Splinter services used by the abandoning node
+will also be stopped using the admin service’s `ServiceOrchestrator`.
+
+Furthermore, the abandoning node’s admin service will remove any peer
+references associated with the circuit and will remove the circuit from that
+node’s `RoutingTable`. This essentially cuts off any communication via the
+circuit from the abandoned node.
+
+
+## Drawbacks
+[drawbacks]: #drawbacks
+
+As the abandon action is only local to the requesting node, this essentially
+‘breaks’ the circuits from the other members’ perspectives. Meaning, consensus
+cannot be reached on the circuit, as the abandoning node will not receive any
+communications via the abandoned circuit. This will require updating how and
+when peer connections are created, updated, and destroyed to keep up with the
+ability of nodes to remove these connections.
+
+## Prior art
+[prior-art]: #prior-art
+
+Circuit deletion has not been implemented in Splinter prior to this design.
+
+## Unresolved questions
+[unresolved]: #unresolved
+
+
+* When a circuit member attempts to reach the member who has abandoned the
+  circuit, what component would be able to communicate that the circuit has
+  been abandoned?
+* Should the admin service attempt to handle circuits that have been abandoned
+  by another circuit member? How would this be handled beyond the current
+  behavior of simply logging that the circuit has been abandoned?

--- a/community/planning/circuit_disband.md
+++ b/community/planning/circuit_disband.md
@@ -29,10 +29,12 @@ also remove the circuit’s networking capability.
 Abandoning a circuit is an alternative route to disbanding a circuit. A node
 may choose to abandon a circuit to disable the circuit's networking from their
 node's perspective. Other circuit members will then be unable to send the
-abandoning node any messages over the abandoned circuit. Disbanding, when
-compared to abandoning, is a safe operation as it requires all members to agree
-before a circuit is completely removed from the network. Once a circuit has
-been disbanded, it is only available locally. This means it has had it’s
+abandoning node any messages over the abandoned circuit. More information can
+be found in the [Circuit Abandon](
+{% link community/planning/circuit_abandon.md %}) feature document. Disbanding,
+when compared to abandoning, is a safe operation as it requires all members to
+agree before a circuit is completely removed from the network. Once a circuit
+has been disbanded, it is only available locally. This means it has had its
 networking capability removed, but the circuit and any service data remains in
 state.
 
@@ -145,7 +147,10 @@ administrators. As such, the disband feature allows time for each system
 administrator to come to a decision externally before agreeing to disband a
 circuit. This also gives administrators the option to reject the disbanding, to
 ensure each administrator has full control over the state of their Splinter
-network. Disbanding a circuit is a relatively safe operation.
+network. Disbanding a circuit is a safer operation compared to the available
+alternative. For information on abandoning a circuit, the alternative to
+disbanding, see the [Circuit Abandon](
+{% link community/planning/circuit_abandon.md %}) feature document.
 
 ## Prior art
 [prior-art]: #prior-art

--- a/community/planning/circuit_purge.md
+++ b/community/planning/circuit_purge.md
@@ -67,7 +67,8 @@ document and ultimately creates a circuit with a `Disbanded` `circuit_status`.
 The `CircuitAbandonRequest` enables a circuit to have a `circuit_status` of
 `Abandoned`. In both of these cases, the circuit networking will have been
 turned off. Once the circuit has been disbanded or abandoned, it is able to be
-purged.
+purged. The [Circuit Abandon]({% link community/planning/circuit_abandon.md %})
+feature document has more information on this operation.
 
 The `CircuitPurgeRequest` is defined in the admin protos as follows:
 

--- a/community/planning/features.md
+++ b/community/planning/features.md
@@ -22,6 +22,7 @@ forum.
 | [Admin UI Profile Redesign]({% link community/planning/admin_ui_profile.md %}) | New designs for the profile page in the splinter Admin UI |
 | [Canopy 0.2]({% link community/planning/canopy_0.2.md %}) | New design of the Canopy system that enables dynamic loading of saplings and improved inter-sapling communication |
 | [Capabilities Repository]({% link community/planning/capabilities-repository.md %}) | A design for a repository and all the surrounding tools and formats for Splinter artifacts. These artifacts include saplings, smart contracts, and capabilities distributions. |
+| [Circuit Abandon]({% link community/planning/circuit_abandon.md %}) | Design for abandoning a circuit |
 | [Circuit Disband]({% link community/planning/circuit_disband.md %}) | Design for removing a circuit's networking capabilities |
 | [Circuit Purge]({% link community/planning/circuit_purge.md %}) | Design for removing a circuit's state data |
 | [REST API Authorization]({% link community/planning/rest_api_authorization.md %}) | Design for securing the Splinter REST API |

--- a/docs/0.5/references/cli/splinter-circuit-abandon.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-abandon.1.md
@@ -1,0 +1,87 @@
+% SPLINTER-CIRCUIT-ABANDON(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-circuit-abandon** — Submits a request to abandon the specified circuit.
+
+SYNOPSIS
+========
+**splinter circuit abandon** \[**FLAGS**\] \[**OPTIONS**\] CIRCUIT-ID
+
+DESCRIPTION
+===========
+Request to abandon a circuit by specifying the circuit ID of the circuit to be
+abandoned. Abandoning a circuit  will remove the circuit's networking ability
+for the abandoning node. This will also notify other circuit members that the
+circuit has been abandoned, but does not require further action from other
+circuit members.
+
+The generated ID of the existing circuit can be viewed using the
+`splinter-circuit-list` command and this circuit ID is used to specify the
+circuit to be abandoned.
+
+This operation is not able to be performed on circuits that are not active at
+the time of the request. As this operation does disconnect the specified circuit
+from its networking capability for the abandoning node, other circuit members
+should take care to notice when the circuit is abandoned so as not to attempt to
+communicate with this circuit member, as this abandoning circuit member has
+disabled the circuit's routing capability from their end. This removes the
+nodes ability to communicate over this circuit.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the full path to the private key file.
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+ARGUMENTS
+=========
+`CIRCUIT-ID`
+: Specify the circuit ID of the circuit to be disbanded.
+
+
+EXAMPLES
+========
+* The existing circuit has ID `1234-ABCDE`.
+
+The following command displays a member node requesting to abandon the circuit:
+```
+$ splinter circuit abandon \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
+  1234-ABCDE \
+```
+
+ENVIRONMENT
+===========
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-circuit-disband(1)`
+| `splinter-circuit-list(1)`
+| `splinter-circuit-purge(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-circuit-disband.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-disband.1.md
@@ -19,9 +19,7 @@ DESCRIPTION
 Request to disband a circuit by specifying the circuit ID of the circuit to be
 disbanded. Disbanding a circuit removes a circuit's networking functionality.
 Once all members of the circuit have accepted the request to disband the
-circuit, the circuit is only available offline. This functionality is currently
-behind the experimental `circuit-disband` feature and must be enabled to use
-this command.
+circuit, the circuit is only available offline.
 
 The `disband` command creates a new circuit proposal to reflect the disbanded
 state, with the proposed circuit's `circuit_status` field set to `Disbanded`.
@@ -75,8 +73,8 @@ EXAMPLES
 The following command displays a member node requesting to disband the circuit:
 ```
 $ splinter circuit disband \
-  --key PROPOSED-MEMBER-NODE-PRIVATE-KEY-FILE \
-  --url URL-of-proposed-member-node-splinterd-REST-API \
+  --key MEMBER-NODE-PRIVATE-KEY-FILE \
+  --url URL-of-member-node-splinterd-REST-API \
   1234-ABCDE \
 ```
 
@@ -87,9 +85,9 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`
-| `splinter-circuit-show(1)`
 | `splinter-circuit-purge(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-circuit-purge.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-purge.1.md
@@ -17,17 +17,25 @@ SYNOPSIS
 DESCRIPTION
 ===========
 Request to purge a circuit by specifying the circuit ID of the circuit to be
-removed from the node's storage. A circuit is only available to be purged
-if it has already been disbanded and are only available locally. Disbanding a
-circuit removes a circuit's networking functionality.
+removed from the node's storage. Internal service data associated with the
+circuit is also purged. A circuit is only able to be purged if it has already
+been deactivated and no longer supports networking. Disbanding a circuit
+removes a circuit's networking functionality, allowing for a circuit to be
+purged. A circuit may also be abandoned, causing the circuit's networking
+capability to be disabled for the abandoning node, so the abandoning node
+is able to purge the deactivated circuit.
 
-The generated ID of the existing disbanded circuit can be viewed using the
-`splinter-circuit-list`, with the `--circuit-status` option of `disbanded`.
+The generated ID of an existing deactivated circuit can be viewed using the
+`splinter-circuit-list`, with the `--circuit-status` option of either
+`disbanded` and/or `abandoned`.
 
-The purge request is only available for members of the node, as the circuit is
-only available to the node locally. If the circuit has not been disbanded, it
-is not able to be purged. Once a circuit has been purged, it is removed from
-the node's storage and is no longer viewable.
+The purge request only works for local circuits that have been deactivated. If
+the circuit is still considered active, it is not able to be purged. Once a
+circuit has been purged, the circuit is removed from the node's admin store and
+any internal Splinter service data will also be removed. If a circuit is using
+the Scabbard service, for example, the state LMDB files associated with the
+circuit are deleted. After purging, the circuit and internal service data are
+no longer available as this state has been deleted.
 
 FLAGS
 =====
@@ -61,7 +69,7 @@ ARGUMENTS
 
 EXAMPLES
 ========
-* The existing disbanded circuit has ID `1234-ABCDE`.
+* The existing inactive circuit has ID `1234-ABCDE`.
 
 The following command displays a member node requesting to purge the circuit:
 ```
@@ -78,8 +86,9 @@ ENVIRONMENT VARIABLES
 
 SEE ALSO
 ========
-| `splinter-circuit-list(1)`
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-disband(1)`
+| `splinter-circuit-list(1)`
 | `splinter-circuit-show(1)`
 |
 | Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter.1.md
+++ b/docs/0.5/references/cli/splinter.1.md
@@ -85,6 +85,7 @@ Many `splinter` subcommands accept the following environment variable:
 SEE ALSO
 ========
 | `splinter-cert-generate(1)`
+| `splinter-circuit-abandon(1)`
 | `splinter-circuit-disband(1)`
 | `splinter-circuit-list(1)`
 | `splinter-circuit-proposals(1)`


### PR DESCRIPTION
Adds a feature doc for the `circuit-abandon` feature and adds the `splinter-circuit-abandon` man page and updates to the related man pages.