### PR TITLE
Fix gameroom build to work with Docker 1.28+

### DIFF
--- a/docs/0.4/examples/gameroom/index.md
+++ b/docs/0.4/examples/gameroom/index.md
@@ -41,7 +41,7 @@ below.
    directory:
 
    ``` console
-   $ docker-compose -f examples/gameroom/docker-compose.yaml up --build
+   $ docker-compose --env-file=.env -f examples/gameroom/docker-compose.yaml up --build
    ```
 
     **Note:** To run Gameroom with experimental features enabled, set an


### PR DESCRIPTION
Explicitly specify path of the gameroom docker .env file. Prior to
Docker 1.28, Docker would attempt to load a .env from the current
working directory by default.  With Docker 1.28+, Docker now instead
attempts to load the .env from the directory of the docker-compose file
by default. This commit explicitly points to the .env file at the base
of the project instead of relying on defaults. It is backwards
compatible with older versions of Docker.

Signed-off-by: Lee Bradley <bradley@bitwise.io>