### PR TITLE
Update smart contract steps

### DIFF
--- a/docs/0.4/howto/uploading_smart_contract.md
+++ b/docs/0.4/howto/uploading_smart_contract.md
@@ -128,7 +128,8 @@ for details on how to create and compile a smart contract
 4. Upload the smart contract.
 
    ``` console
-   $ scabbard contract upload ./my_contract.scar \
+   $ scabbard contract upload <contract_name>:<version_requirement> \
+       --path <path_to_contract_scar_file> \
        --key <path_to_alpha_node_private_key> \
        --url http://splinterd-alpha:8080 \
        --service-id $CIRCUIT_ID::scabbard-service-alpha

--- a/docs/0.5/howto/uploading_smart_contract.md
+++ b/docs/0.5/howto/uploading_smart_contract.md
@@ -125,7 +125,8 @@ for details on how to create and compile a smart contract
 4. Upload the smart contract.
 
    ``` console
-   $ scabbard contract upload ./my_contract.scar \
+   $ scabbard contract upload <contract_name>:<version_requirement> \
+       --path <path_to_contract_scar_file> \
        --key <path_to_alpha_node_private_key> \
        --url http://splinterd-alpha:8080 \
        --service-id $CIRCUIT_ID::a000

--- a/docs/0.5/tutorials/configuring_splinter_nodes.md
+++ b/docs/0.5/tutorials/configuring_splinter_nodes.md
@@ -602,7 +602,7 @@ as the contract’s owners.
 
     ```bash
     root@scabbard-cli-beta:/# scabbard cr create \
-      sawtooth_xo \
+      xo \
       --owners $(cat /config/keys/beta.pub) \
       --key /config/keys/beta.priv \
       --url 'http://splinterd-beta:8080' \


### PR DESCRIPTION
This PR updates instructions related to uploading smart contracts in the Uploading a Smart Contract and Configuring Two Splinter Nodes

In Uploading a Smart Contract the scabbard contract upload command was using the scar file path as the scar argument in the command but the scabbard CLI requires the argument be formatted: NAME:VERSION_REQ

The manifest in the xo scar file used in Configuring Two Splinter Nodes was updated so the contract name matches the scar file name, this update requires the contract registry name be updated to match.