### PR TITLE
Enable jekyll autoregeneration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,9 +29,9 @@ services:
       bash -c "
         rm -rf  _site .jekyll-cache
         if [ -f _userconfig.yml ]; then
-           jekyll serve --config _config.yml,_userconfig.yml
+           jekyll serve --watch --config _config.yml,_userconfig.yml
         else
-           jekyll serve
+           jekyll serve --watch
         fi
       "
 


### PR DESCRIPTION
Without this option, the jekyll server must be restarted for changes to be
reflected in the generated files.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>