### PR TITLE
Update docs for 0.5.8 release

### DIFF
--- a/docs/0.5/references/api/openapi.yml
+++ b/docs/0.5/references/api/openapi.yml
@@ -15,7 +15,7 @@
 openapi: '3.0.0'
 
 info:
-  version: 0.5.7
+  version: 0.5.8
   title: splinterd API
   description: REST API for the Splinter daemon
 
@@ -2152,7 +2152,7 @@ components:
         version:
           description: Rest API version
           type: string
-          example: "0.5.7"
+          example: "0.5.8"
         node_id:
           description: Node id
           type: string

--- a/docs/0.5/references/cli/splinter-authid-list.1.md
+++ b/docs/0.5/references/cli/splinter-authid-list.1.md
@@ -21,7 +21,7 @@ This command lists all of the authorized identities with assigned roles the
 local node has configured. This command displays abbreviated information
 pertaining to assignments in columns, with the headers `ID`, `TYPE`, and
 `ROLES`. This allows the user to quickly see which identities have been assigned
-roles, as well as how many.  The information displayed is only relevant to the
+roles, as well as how many. The information displayed is only relevant to the
 queried splinter node.
 
 FLAGS

--- a/docs/0.5/references/cli/splinter-circuit-propose.1.md
+++ b/docs/0.5/references/cli/splinter-circuit-propose.1.md
@@ -54,6 +54,10 @@ FLAGS
 
 OPTIONS
 =======
+`--auth-type AUTHORIZATION_TYPE`
+: Authorization type for the circuit. Possible values `trust` or `challenge`.
+  Defaults to `trust`. If using `challenge`, node public keys are required.
+
 `--comments COMMENTS`
 : Adds human-readable comments to the circuit proposal.
 
@@ -85,6 +89,13 @@ OPTIONS
   for the given node ID. The proposer must also specify its own node, if it is
   to be be included on the circuit proposal. Repeat this option to specify
   multiple nodes.
+
+`--node-public-key NODE-PUBLIC-KEY-STRING` ...
+: Specifies the public key for node, using the format `NODE-ID::PUBLIC-KEY`.
+  The proposer must also specify its own node's public key, if it is
+  to be be included on the circuit proposal. Repeat this option to specify keys
+  for multiple nodes. Public keys are required if using `challenge`
+  authorization.
 
 `--service SERVICE-STRING` ...
 : Specifies the service ID and allowed nodes, using the format

--- a/docs/0.5/references/cli/splinter-keygen.1.md
+++ b/docs/0.5/references/cli/splinter-keygen.1.md
@@ -94,6 +94,19 @@ writing file: "/etc/splinter/keys/splinterd.priv"
 writing file: "/etc/splinter/keys/splinterd.pub"
 ```
 
+ENVIRONMENT VARIABLES
+=====================
+
+**SPLINTER_CONFIG_DIR**
+: Specifies the directory containing configuration files, including system keys.
+  (See: `--config-dir`.)
+
+**SPLINTER_HOME**
+
+: Changes the base directory path for the Splinter directories, including the
+  config directory and system key location. (See the `splinterd(1)` man page for
+  more information.) This value is not used if `SPLINTER_CONFIG_DIR` is set.
+
 SEE ALSO
 ========
 

--- a/docs/0.5/references/cli/splinter-role.1.md
+++ b/docs/0.5/references/cli/splinter-role.1.md
@@ -42,8 +42,20 @@ FLAGS
 SUBCOMMANDS
 ===========
 
+`create`
+: Creates a role on a Splinter node
+
+`delete`
+: Deletes a role from a splinter node
+
 `list`
 : Lists the available roles for a Splinter node
+
+`show`
+: Shows a role on a Splinter node
+
+`update`
+: Updates a role on a Splinter node
 
 SEE ALSO
 ========

--- a/docs/0.5/references/cli/splinter-upgrade.1.md
+++ b/docs/0.5/references/cli/splinter-upgrade.1.md
@@ -1,0 +1,71 @@
+% SPLINTER-UPGRADE(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-upgrade** — Upgrades splinter yaml state to database state
+
+SYNOPSIS
+========
+
+**splinter** **upgrade** \[**FLAGS**\]
+
+DESCRIPTION
+===========
+Upgrades splinter by importing data from the deprecated yaml state file format
+to a database. This tool searches for data in the `circuits.yaml` and
+`circuit-proposals.yaml` state definitions from the state directory. When the
+upgrade is complete, the yaml state definitions will be renamed to
+`circuits.yaml.old` and `circuit-proposals.yaml.old` respectively.
+
+OPTIONS
+=======
+`-S`, `--state-dir` `STATE-DIR`
+: Specifies the storage directory.  (Defaults to `/var/lib/splinter`, unless
+`SPLINTER_STATE_DIR` or `SPLINTER_HOME` is set.)
+
+`-C`, `--connect` `DB-URL`
+: Specifies the URL or connection string for the PostgreSQL or SQLite database
+used for Splinter state, The default SQLite database will go in the directory,
+`/var/lib/splinter`, unless `SPLINTER_STATE_DIR` or `SPLINTER_HOME` is set.
+
+EXAMPLES
+========
+This example upgrades splinter by connecting to a PostgreSQL server
+with the example hostname and port `splinter-db-alpha:5432`.
+
+```
+splinter upgrade -C postgres://admin:admin@splinter-db-alpha:5432/splinter
+```
+
+This example upgrades splinter connecting to the SQLite database `./custom-sqlite.db`
+and using YAML state files from `./custom/dir`.
+
+```
+splinter upgrade -S ./custom/dir -C ./custom-sqlite.db
+```
+
+ENVIRONMENT
+===========
+The following environment variables affect the execution of the command.
+
+**SPLINTER_STATE_DIR**
+
+: Defines the default state directory for yaml state and SQLite. This is
+overridden by the `--state-dir` flag
+
+**SPLINTER_HOME**
+
+: Defines the default splinter home directory, from which the state directory
+is derived as `$SPLINTER_HOME/data`. This environment variable is not used if
+either the `SPLINTER_STATE_DIR` environment variable or the `--state-dir` flag
+is set.
+
+SEE ALSO
+========
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter-user-list.1.md
+++ b/docs/0.5/references/cli/splinter-user-list.1.md
@@ -1,0 +1,84 @@
+% SPLINTER-USER-LIST(1) Cargill, Incorporated | Splinter Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**splinter-user-list** — Displays the existing users for this Splinter node.
+
+SYNOPSIS
+========
+**splinter user list** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command lists all of the users the local node has. This command
+displays abbreviated information pertaining to users in columns, with the
+headers `ID`, `USERNAME`, and `TYPE`. This makes it possible to view all the
+users registered with the local node, either through Biome or through one of
+the various Splinter-supported OAuth providers. The `USERNAME` is either a
+Biome user's `username` submitted at registration or the main `username` as
+determined by an OAuth provider. The `TYPE` column displays the method used by
+the user to register with Splinter, currently either `Biome` or `OAuth`. The
+`ID` column maps to the user's internal ID, which is used while assigning
+authorizations to a user.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-F`, `--format` FORMAT
+: Specifies the output format of the list. (default `human`). Possible values
+  for formatting are `human` and `csv`.
+
+`-k`, `--key` PRIVATE-KEY-FILE
+: Specifies the private signing key (either a file path or the name of a
+  .priv file in $HOME/.splinter/keys).
+
+`-U`, `--url` URL
+: Specifies the URL for the `splinterd` REST API. The URL is required unless
+  `$SPLINTER_REST_API_URL` is set.
+
+EXAMPLES
+========
+This command displays information about Splinter users with a default `human`
+formatting, meaning the information is displayed in a table.
+
+```
+$ splinter user list \
+  --url URL-of-splinterd-REST-API
+ID                                    USERNAME    TYPE
+f35aacc1-a9cd-4eda-b6d0-2efaddf0c8a4  oauth_user  OAuth
+3no4hz9g-628s-m20x-b9a3-4ijodc402973  biome_user  Biome
+```
+
+ENVIRONMENT VARIABLES
+=====================
+**SPLINTER_REST_API_URL**
+: URL for the `splinterd` REST API. (See `-U`, `--url`.)
+
+SEE ALSO
+========
+| `splinter-role(1)`
+| `splinter-role-create(1)`
+| `splinter-permissions(1)`
+|
+| Splinter documentation: https://www.splinter.dev/docs/0.5/

--- a/docs/0.5/references/cli/splinter.1.md
+++ b/docs/0.5/references/cli/splinter.1.md
@@ -55,6 +55,9 @@ SUBCOMMANDS
 `registry`
 : Provides commands to create and manage Splinter registry information.
 
+`upgrade`
+: Upgrades splinter yaml state to database state
+
 FLAGS
 =====
 
@@ -84,6 +87,11 @@ Many `splinter` subcommands accept the following environment variable:
 
 SEE ALSO
 ========
+| `splinter-authid-create(1)`
+| `splinter-authid-delete(1)`
+| `splinter-authid-list(1)`
+| `splinter-authid-show(1)`
+| `splinter-authid-update(1)`
 | `splinter-cert-generate(1)`
 | `splinter-circuit-abandon(1)`
 | `splinter-circuit-disband(1)`
@@ -99,8 +107,12 @@ SEE ALSO
 | `splinter-database-migrate(1)`
 | `splinter-health-status(1)`
 | `splinter-keygen(1)`
+| `splinter-role-create(1)`
+| `splinter-role-delete(1)`
 | `splinter-role-list(1)`
 | `splinter-role-show(1)`
+| `splinter-role-update(1)`
+| `splinter-upgrade(1)`
 |
 | `splinterd(1)`
 |

--- a/docs/0.5/references/cli/splinterd.1.md
+++ b/docs/0.5/references/cli/splinterd.1.md
@@ -213,7 +213,7 @@ OPTIONS
 
 `--tls-ca-file CERT-FILE`
 : Specifies the path and file name for the trusted CA certificate.
-  (Default: `/etc/splinter/certs/ca_pem`.)
+  (Default: `/etc/splinter/certs/ca.pem`.)
 
   Do not use this option with the `--tls-insecure` flag.
 


### PR DESCRIPTION
These changes were generated using the `just copy-docs` command.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>