### PR TITLE
Add Note about required format for service args with 0.4 node

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -43,6 +43,12 @@ img {
     max-width: 100%;
 }
 
+blockquote {
+    background-color: var(--light-gray);
+    border-radius: 5px;
+    padding: 10px;
+}
+
 .btn-primary {
     background-color: var(--light-splinter-fuchsia);
     border-color: var(--light-splinter-fuchsia);

--- a/docs/0.5/tutorials/configuring_splinter_nodes_with_docker.md
+++ b/docs/0.5/tutorials/configuring_splinter_nodes_with_docker.md
@@ -389,8 +389,8 @@ beta nodes.
       --service gsAA::alpha \
       --service-type *::scabbard \
       --management example \
-      --service-arg *::admin_keys=$(cat /config/keys/beta.pub) \
-      --service-peer-group gsBB,gsAA
+      --service-peer-group gsBB,gsAA \
+      --service-arg *::admin_keys=$(cat /config/keys/beta.pub)
     ```
 
     Let's take a look at the options needed to create a circuit proposal.
@@ -429,6 +429,11 @@ beta nodes.
     application authorization handler which handles the circuit’s change
     proposals.
 
+    `--service-peer-group gsBB,gsAA` Service peer group (a list of peer
+    services). Peer services are services used by peer nodes within a circuit.
+    This is the group of services that must come to consensus amongst the node
+    peers.
+
     `--service-arg *::admin_keys=$(cat /config/keys/beta.pub)`: String that
     passes key/value arguments to the specified service. As with
     `--service-type` above, the glob operator, `*`, can be used to match all or
@@ -436,10 +441,16 @@ beta nodes.
     key of the smart contract administrator who's is allowed to upload smart
     contracts to the circuit.
 
-    `--service-peer-group gsBB,gsAA` Service peer group (a list of peer
-    services). Peer services are services used by peer nodes within a circuit.
-    This is the group of services that must come to consensus amongst the node
-    peers.
+    > **NOTE:**
+    >  Due to changes in the CLI, if creating a circuit with a 0.4
+    >  splinter node the `--service-arg` must be wrapped in a JSON list.
+    >
+    >  `--service-arg *::admin_keys="[\"$(cat /config/keys/beta.pub)\"]" `
+    >
+    > To ensure the rest of the circuit configuration is compatible with 0.4
+    > add the following `--compat` options.
+    >
+    >  `--compat 0.4`
 
 
 1. The output of the `propose` command shows that it was submitted to the REST


### PR DESCRIPTION
To support service-args that are not wrapped in json list,
the default formatting for the argument has changed. To be
backwards compatibly with 0.4, the service args value needs
to be explicitly set in a json list.

Also mentions --compat 0.4 for circuits compatible with 0.4.

Commit rearranges the options a little bit to make the note look
better.

Finally adds css for blockquotes:

<img width="918" alt="Screen Shot 2021-09-27 at 11 08 59 AM" src="https://user-images.githubusercontent.com/18215486/134945332-09f6d025-47c0-4a56-a6c5-1cdb3fea075b.png">
