### PR TITLE
Update the default values in the logging docs

### DIFF
--- a/docs/0.6/howto/configure_logging.md
+++ b/docs/0.6/howto/configure_logging.md
@@ -111,19 +111,15 @@ encoder = "[{d(%Y-%m-%d %H:%M:%S%.3f)}] T[{T}] {l} [{M}] {m}\n"
 
 [loggers.root]
 appenders = ["stdout"]
-level = "Trace"
-
-[loggers.tokio]
-appenders = ["stdout"]
 level = "Warn"
 
-[loggers.tokio_reactor]
+[loggers.splinter]
 appenders = ["stdout"]
-level = "Warn"
+level = "Info"
 
-[loggers.hyper]
+[loggers.splinterd]
 appenders = ["stdout"]
-level = "Warn"
+level = "Info"
 ```
 
 ### Redirect Splinter Daemon logs to file
@@ -178,15 +174,11 @@ logged to stdout. This is not recommended and may cause performance issues.
 appenders = ["stdout"]
 level = "Trace"
 
-[loggers.tokio]
+[loggers.splinter]
 level = "Trace"
 
-[loggers.tokio_reactor]
+[loggers.splinterd]
 level = "Trace"
-
-[loggers.hyper]
-level = "Trace"
-
 ```
 
 ## Procedure


### PR DESCRIPTION
Updating the root logger to have the 'Warn' level as well as updating the other
included loggers with the 'splinter' and 'splinterd' names and `Info` levels to
match splinterd.

Signed-off-by: Caleb Hill <hill@bitwise.io>