### PR TITLE
Move Apache rewrite rules out of Dockerfiles

### DIFF
--- a/apache/rewrite.conf
+++ b/apache/rewrite.conf
@@ -1,0 +1,21 @@
+# Copyright 2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LoadModule rewrite_module modules/mod_rewrite.so
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule ^/(.*).md$ /\$1.html [NC,L,R]
+RewriteRule ^/docs/0.5$ /docs/0.6/ [NC,L,R]
+RewriteRule ^/docs/0.5/(.*)$ /docs/0.6/$1 [NC,L,R]

--- a/ci/website.dockerfile
+++ b/ci/website.dockerfile
@@ -70,16 +70,13 @@ COPY --from=jekyll /tmp/ /usr/local/apache2/htdocs/
 COPY --from=redoc /index_0.4.html /usr/local/apache2/htdocs/docs/0.4/api/index.html
 COPY --from=redoc /index_0.6.html /usr/local/apache2/htdocs/docs/0.6/api/index.html
 COPY --from=git /commit-hash /commit-hash
+COPY apache/rewrite.conf /usr/local/apache2/conf/rewrite.conf
 
 RUN echo "\
 \n\
 ServerName splinter.dev\n\
+Include /usr/local/apache2/conf/rewrite.conf\n\
 AddDefaultCharset utf-8\n\
-LoadModule rewrite_module modules/mod_rewrite.so\n\
-RewriteEngine on\n\
-RewriteCond %{REQUEST_FILENAME} !-d\n\
-RewriteCond %{REQUEST_FILENAME} !-f\n\
-RewriteRule ^/(.*).md$ /\$1.html [NC,L,R]\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf
 

--- a/docker/splinter-docs-apache
+++ b/docker/splinter-docs-apache
@@ -14,26 +14,22 @@
 
 FROM httpd:2.4
 
+COPY apache/rewrite.conf /usr/local/apache2/conf/rewrite.conf
+
 RUN echo "\
 \n\
 ServerName splinter-docs-apache\n\
+Include /usr/local/apache2/conf/rewrite.conf\n\
 AddDefaultCharset utf-8\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n\
-LoadModule rewrite_module modules/mod_rewrite.so\n\
 ProxyPass /docs/0.4/api/ http://splinter-docs-redoc-0-4:4001/\n\
 ProxyPassReverse /docs/0.4/api/ http://splinter-docs-redoc-0-4:4001/\n\
 ProxyPass /docs/0.6/api/ http://splinter-docs-redoc-0-6:4002/\n\
 ProxyPassReverse /docs/0.6/api/ http://splinter-docs-redoc-0-6:4002/\n\
 ProxyPass / http://splinter-docs:4000/\n\
 ProxyPassReverse / http://splinter-docs:4000/\n\
-RewriteEngine on\n\
-RewriteCond %{REQUEST_FILENAME} !-d\n\
-RewriteCond %{REQUEST_FILENAME} !-f\n\
-RewriteRule ^/(.*).md$ /\$1.html [NC,L,R]\n\
-RewriteRule ^/docs/0.5$ /docs/0.6/ [NC,L,R]\n\
-RewriteRule ^/docs/0.5/(.*)$ /docs/0.6/\$1 [NC,L,R]\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf
 


### PR DESCRIPTION
Having the rewrite rules in a single shared file ensures that the latest
updates are always in the environment used for development as well as the
deployable docker image.

This change also removes the need for potentially complicated escaping
required when using "echo >".

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>