### PR TITLE
Install Jekyll on ruby instead of using published image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,9 +29,9 @@ services:
       bash -c "
         rm -rf  _site .jekyll-cache
         if [ -f _userconfig.yml ]; then
-           jekyll serve --watch --config _config.yml,_userconfig.yml
+           jekyll serve -H 0.0.0.0 --watch --config _config.yml,_userconfig.yml
         else
-           jekyll serve --watch
+           jekyll serve -H 0.0.0.0 --watch
         fi
       "
 

--- a/docker/splinter-docs-jekyll
+++ b/docker/splinter-docs-jekyll
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jekyll/jekyll:3.8
+FROM ruby
+
+RUN gem install jekyll -- --use-system-libaries
 
 RUN gem install \
     bundler \
@@ -23,3 +25,13 @@ RUN gem install \
     jekyll-seo-tag \
     jekyll-target-blank \
     jekyll-titles-from-headings
+
+RUN gem install webrick
+
+ENV JEKYLL_ENV=development
+
+CMD ["jekyll", "--help"]
+WORKDIR /srv/jekyll
+VOLUME  /srv/jekyll
+EXPOSE 35729
+EXPOSE 4000


### PR DESCRIPTION
The `ruby` base image is published for multiple architectures, so this
change ensures that the jekyll image runs without emulation.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>