### PR TITLE
Add css for img.centered

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -575,3 +575,9 @@ th {
 td {
     padding: unset;
 }
+
+img.centered {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
With this being included, {:.centered} can be added
at the end of an image to center the img.

for example:

![Lifecycle Integration Admin Service]({% link images/admin_lifecycle.svg %}
  "Lifecycle Integration with Admin Service"){:.centered}

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>