### PR TITLE
Fix error in biome user management doc

### DIFF
--- a/docs/0.7/concepts/biome_user_management.md
+++ b/docs/0.7/concepts/biome_user_management.md
@@ -337,7 +337,7 @@ The request header must contain the user's current access token, and the request
 body is empty. For example:
 
 ```
-    POST /biome/logout
+    PATCH /biome/logout
     Authorization: bearer eyJ0eXAiOikZjBjOGE0I...aXNzIjoic2PEUXY70Ehc
     {}
 ```


### PR DESCRIPTION
The biome user management doc used the wrong method in the "logging out"
example. This commit updates the example from `POST /biome/logout` to
`PATCH /biome/logout`.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>